### PR TITLE
Handle URL decoding

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -114,6 +114,8 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	} else {
 		var mimeType string
 		if resolveMode == ResolveModeManual {
+			undecoded := req.RequestURI
+			w3url.RawPath = undecoded[strings.Index(undecoded[1:], "/")+1:]
 			bs, mimeType, err = handleManualMode(w, w3url)
 		} else {
 			bs, mimeType, err = handleAutoMode(w, w3url)


### PR DESCRIPTION
In `manual` mode the undecoded path is sent as calldata to smart contracts.
In `auto` and `5219` mode we use URL decoded by HTTP request.
