### PR TITLE
custom domain support 

### DIFF
--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"context"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+var certManager = autocert.Manager{
+	Prompt: autocert.AcceptTOS,
+	// HostPolicy: autocert.HostWhitelist(domain),
+	HostPolicy: func(ctx context.Context, host string) error {
+		return nil
+	}, //your domain here
+	Cache: autocert.DirCache("certs"), //folder for storing certificates
+	Email: "",
+}

--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -2,16 +2,81 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"golang.org/x/crypto/acme/autocert"
 )
 
-var certManager = autocert.Manager{
-	Prompt: autocert.AcceptTOS,
-	// HostPolicy: autocert.HostWhitelist(domain),
-	HostPolicy: func(ctx context.Context, host string) error {
-		return nil
-	}, //your domain here
-	Cache: autocert.DirCache("certs"), //folder for storing certificates
-	Email: "",
+type ExtendCache struct {
+	autocert.DirCache
+}
+
+func (c *ExtendCache) Get(ctx context.Context, name string) ([]byte, error) {
+	return c.DirCache.Get(ctx, name)
+}
+
+func (c *ExtendCache) Put(ctx context.Context, name string, data []byte) error {
+	return c.DirCache.Put(ctx, name, data)
+}
+
+func (c *ExtendCache) Delete(ctx context.Context, name string) error {
+	return c.DirCache.Delete(ctx, name)
+}
+
+var (
+	cache = &ExtendCache{
+		DirCache: autocert.DirCache("certs"), //folder for storing certificates
+	}
+	certManager = autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		// HostPolicy: autocert.HostWhitelist(domain),
+		HostPolicy: func(ctx context.Context, host string) error {
+			return nil
+		}, //your domain here
+		Cache: cache,
+		Email: config.AutoCertEmail,
+	}
+)
+
+func tryFindSystemCertificate(domain string) (*tls.Certificate, error) {
+
+	var (
+		findCert *tls.Certificate = nil
+		findErr                   = fmt.Errorf("no certificate found for %s", domain)
+	)
+
+	if config.SystemCertDir != "" {
+		if stat, err := os.Stat(config.SystemCertDir); err == nil && stat.IsDir() {
+			filepath.WalkDir(config.SystemCertDir, func(path string, d os.DirEntry, err error) error {
+				if err == nil {
+					if data, err := os.ReadFile(path); err == nil {
+						if cert, err := tls.X509KeyPair(data, data); err == nil {
+							if len(cert.Certificate) > 0 {
+								if cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0]); err == nil {
+									if cert.Leaf.VerifyHostname(domain) == nil {
+										findCert = &cert
+										findErr = nil
+										return nil
+									}
+								}
+							}
+						}
+					}
+				}
+				return nil
+			})
+		}
+	}
+	return findCert, findErr
+}
+
+func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if cert, err := tryFindSystemCertificate(hello.ServerName); err == nil && cert != nil {
+		return cert, nil
+	}
+	return certManager.GetCertificate(hello)
 }

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -23,6 +23,8 @@ type Web3Config struct {
 	CertificateFile string
 	KeyFile         string
 	RunAsHttp       bool
+	AutoCertEmail   string
+	SystemCertDir   string
 	DefaultChain    int
 	HomePage        string
 	CORS            string

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/naoina/toml"
@@ -22,6 +22,7 @@ type Web3Config struct {
 	Verbosity       int
 	CertificateFile string
 	KeyFile         string
+	RunAsHttp       bool
 	DefaultChain    int
 	HomePage        string
 	CORS            string
@@ -87,8 +88,6 @@ func loadConfig(file string, cfg *Web3Config) error {
 	}
 	return err
 }
-
-
 
 func getDefaultNSSuffix() (string, error) {
 	if config.DefaultChain == 0 {
@@ -157,7 +156,7 @@ func getChainById(chainId string) string {
 // uniswap.eth:gor -> uniswap.eth:5
 // uniswap.eth:5 -> uniswap.eth:5
 // uniswap.eth -> uniswap.eth
-func hostChangeChainShortNameToId(host string) (string) {
+func hostChangeChainShortNameToId(host string) string {
 	hostParts := strings.Split(host, ":")
 	if len(hostParts) == 1 {
 		return hostParts[0]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -254,7 +254,7 @@ func main() {
 		server := &http.Server{
 			Addr: ":https",
 			TLSConfig: &tls.Config{
-				GetCertificate: certManager.GetCertificate,
+				GetCertificate: GetCertificate,
 				NextProtos:     []string{http2.NextProtoTLS, "http/1.1"},
 				MinVersion:     tls.VersionTLS12,
 			},

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -241,8 +241,8 @@ func main() {
 		}
 	})
 
-	log.Infof("Serving on http://localhost:%v\n", config.ServerPort)
-	if config.CertificateFile == "" || config.KeyFile == "" {
+	if config.RunAsHttp {
+		log.Infof("Serving on http://localhost:%v\n", config.ServerPort)
 		log.Info("Running server in unsecure mode...")
 		err := http.ListenAndServe(":"+config.ServerPort, nil)
 		if err != nil {
@@ -250,6 +250,7 @@ func main() {
 			return
 		}
 	} else {
+		log.Infof("Serving on https mode ")
 		server := &http.Server{
 			Addr: ":https",
 			TLSConfig: &tls.Config{

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -24,7 +24,7 @@ func handle(w http.ResponseWriter, req *http.Request) {
 		log.Infof("cname is ---> %s", cname)
 		if strings.HasSuffix(cname, ".") {
 			h = cname[:len(cname)-1]
-			w.Header().Set("We3-CNAME", cname)
+			w.Header().Set("Web3-CNAME", cname)
 		}
 
 	}

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -21,7 +21,12 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	h := req.Host
 
 	if cname, err := net.LookupCNAME(h); err == nil {
-		h = cname
+		log.Infof("cname is ---> %s", cname)
+		if strings.HasSuffix(cname, ".") {
+			h = cname[:len(cname)-1]
+			w.Header().Set("We3-CNAME", cname)
+		}
+
 	}
 
 	path := req.URL.EscapedPath()
@@ -47,6 +52,8 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	if len(req.URL.RawQuery) > 0 {
 		web3Url += "?" + req.URL.RawQuery
 	}
+
+	log.Infof("web3url : %s", web3Url)
 
 	// Fetch the web3 URL
 	fetchedWeb3Url, err := web3protocolClient.FetchUrl(web3Url)

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,4 +1,5 @@
 ServerPort = "80"
+RunAsHttp = false
 CertificateFile = ""
 KeyFile = ""
 HomePage = "/home.w3q/"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,10 +1,13 @@
 ServerPort = "80"
 RunAsHttp = false
+AutoCertEmail = ""
+SystemCertDir = ""
 CertificateFile = ""
 KeyFile = ""
 HomePage = "/home.w3q/"
 CORS = "*" # list of domains from which to accept cross origin requests (browser enforced)
 defaultChain = 0
+
 
 # default chain for supported domain
 [nsDefaultChains]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -168,6 +168,6 @@ defaultChain = 0
     "ChainID" = 84531
     "RPC" = "https://goerli.base.org"
 
-    [chainConfigs."3333"]
-    "ChainID" = "3333"
+    [chainConfigs.3333]
+    "ChainID" = 3333
     "RPC" = "http://88.99.30.186:9545"


### PR DESCRIPTION
This help gateway  support the gateway custom domain name by [autocert](golang.org/x/crypto/acme/autocert). 

At first user should have the web3 deployed contract like : 

http://0xe15406f9092cb0cb77191fa3cbee92df07c9cc8b.80001.w3link.io/getMessage

Then add the Cname record as 

yourname.example.com ->  with value 0xe15406f9092cb0cb77191fa3cbee92df07c9cc8b.80001.w3link.io . 

At last visit  https://yourname.example.com . 
