### PR TITLE
fix no system cert loaded for new links

### DIFF
--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -124,7 +124,7 @@ func tryFindSystemCertificate(domain string) (*tls.Certificate, error) {
 			return nil
 		}
 		cache.Put(context.Background(), domainSysCertPath, []byte(path))
-		return nil
+		return filepath.SkipAll
 	})
 
 	return findCert, err


### PR DESCRIPTION
Fix issue: 
cannot access URLs that match the system certificate

Root cause: 
`filepath.WalkDir()` stops traversing the file in the configured system certificate path when an error is returned by the anonymous function, which causes the system certificate not to be loaded.

Solution:
return no error in the anonymous function of `filepath.WalkDir()`