### PR TITLE
Bump to web3protocol-go@0.2.3; Require go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,17 @@
 module github.com/ethstorage/web3url-gateway
 
-go 1.17
+go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.2
+	github.com/web3-protocol/web3protocol-go v0.2.3
 	golang.org/x/net v0.16.0
 )
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
+github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
 github.com/aws/aws-sdk-go-v2/config v1.1.1/go.mod h1:0XsVy9lBI/BCXm+2Tuvt39YmdHwS5unDQmxZOYe8F5Y=
@@ -479,6 +481,8 @@ github.com/web3-protocol/web3protocol-go v0.2.1 h1:f5LNqXWa/fcL6VXI/Gk5sUE81Ytjr
 github.com/web3-protocol/web3protocol-go v0.2.1/go.mod h1:0sL433yN4XUKVfZSMQIal+m3vTovLpcsiuvteVJ83QY=
 github.com/web3-protocol/web3protocol-go v0.2.2 h1:JHRSTXiIirogHxvHTwnM0XgJolyYeRqUz/iDVcCj81Y=
 github.com/web3-protocol/web3protocol-go v0.2.2/go.mod h1:0sL433yN4XUKVfZSMQIal+m3vTovLpcsiuvteVJ83QY=
+github.com/web3-protocol/web3protocol-go v0.2.3 h1:EpgiROKkcIDV7MsE/bSqgdX2ogvrYT0g66NpPIJwWes=
+github.com/web3-protocol/web3protocol-go v0.2.3/go.mod h1:zDrTDbmVmNtY7x/ZZ8Wo9uBn/51aKNzd3OUoqv48BsE=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

This bump web3protocol-go at 0.2.3, which add support for [ERC-7618](https://github.com/ethereum/ERCs/pull/246) (Add Content-encoding handling in ERC-6944 resource request mode).

Test:
https://0xb464cac335daec57d4f50657ec846c3109c774b2.3334.w3link.io/gzip.js
will work as before, but the actual returned data will already be decompressed, and the HTTP header `Content-encoding: gzip` won't be sent to the client.

Also, unrelated to web3protocol-go, I saw the use of filepath.SkipAll which was introduced in go 1.20 so I bumped the value in go.mod.