### PR TITLE
HTML injection: Also handle content-type "text/html" with a suffix

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -144,7 +144,7 @@ func handle(w http.ResponseWriter, req *http.Request) {
 		// If the content type is text/html, we do some processing on the data
 		// - patching the fetch() JS function so that it works with web3:// URLs
 		// - Handling <a> links to absolute web3:// URLs
-		if w.Header().Get("Content-Type") == "text/html" {
+		if strings.HasPrefix(w.Header().Get("Content-Type"), "text/html") {
 			n = patchHTMLFile(buf, n, w.Header().Get("Content-Encoding"))
 		}
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -16,6 +16,7 @@ defaultChain = 0
 
 # support chain name convention
 [name2chain]
+"es-t" = 3333
 "w3q-g" = 3334
 "eth" = 1
 "gor" = 5


### PR DESCRIPTION
Reason : The content-type could also have a prefix, such as `text/html; charset=utf-8`.

Also add es-t as a shortname.