### PR TITLE
Fix "acme/autocert: missing certificate"

### DIFF
--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -48,16 +48,19 @@ var (
 func getCertFromPath(domain, path string) (*tls.Certificate, error) {
 
 	var (
-		err  error
-		data []byte
-		cert tls.Certificate
+		err       error
+		data, key []byte
+		cert      tls.Certificate
 	)
 
 	if data, err = os.ReadFile(path); err != nil {
 		return nil, err
 	}
+	if key, err = os.ReadFile(config.KeyFile); err != nil {
+		return nil, err
 
-	if cert, err = tls.X509KeyPair(data, data); err != nil {
+	}
+	if cert, err = tls.X509KeyPair(data, key); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
__Issue to address__
Error happens when trying to access https://0xb10fe009b82ed3319b4721b84e9ef64d5c5b52c9.11155111.web3gateway.dev
```
http: TLS handshake error from 103.121.208.149:57655: acme/autocert: missing certificate
```

It seems Autocert cannot get the certificate of the CA server when trying to create a new certificate.

__Caused by__

Privete key was not passed to `tls.X509KeyPair`

__Changes made__

Load private key from `KeyFile` defined in config.

__Tests__

https://0xb10fe009b82ed3319b4721b84e9ef64d5c5b52c9.11155111.web3gateway.dev works, as well as other link examples.