### PR TITLE
Add cache support

### DIFF
--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -39,6 +39,7 @@ type PageCacheConfig struct {
 	MaxEntries int
 	MaxEntrySize int // In bytes
 	CacheDuration int // In seconds
+	ImmutableUrlRegexps []string
 }
 
 type NameServiceInfo struct {

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -28,9 +28,17 @@ type Web3Config struct {
 	DefaultChain    int
 	HomePage        string
 	CORS            string
+	PageCache       PageCacheConfig
 	NSDefaultChains map[string]int
 	Name2Chain      map[string]int
 	ChainConfigs    map[int]ChainConfig
+}
+
+type PageCacheConfig struct {
+	Enabled bool
+	MaxEntries int
+	MaxEntrySize int // In bytes
+	CacheDuration int // In seconds
 }
 
 type NameServiceInfo struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,16 +7,16 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
-
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/web3-protocol/web3protocol-go"
+	golanglru2 "github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 var (
@@ -35,6 +35,7 @@ var (
 	nsInfos, chainInfos, nsChains arrayFlags
 	config                        Web3Config
 	web3protocolClient            *web3protocol.Client
+	pageCache                     *golanglru2.LRU[PageCacheKey,PageCacheEntry]
 	majorVersion                  = "0"
 	minorVersion                  = "2"
 	patchVersion                  = "0"
@@ -91,6 +92,10 @@ func initConfig() {
 	}
 	if cors.set {
 		config.CORS = cors.value
+	}
+	// Page cache size: not use the default of unlimited, will only end in crashed servers
+	if config.PageCache.MaxEntries == 0 {
+		config.PageCache.MaxEntries = 1000
 	}
 	for _, c := range chainInfos {
 		ss := strings.Split(c, ",")
@@ -210,6 +215,15 @@ func initWeb3protocolClient() {
 
 	// Create the web3:// client
 	web3protocolClient = web3protocol.NewClient(&web3pConfig)
+
+	// Set the verbosity level
+	web3protocolClient.Logger.SetLevel(log.Level(config.Verbosity))
+	web3protocolClient.Logger.SetFormatter(&log.TextFormatter{TimestampFormat: "2006-01-02 15:04:05", FullTimestamp: true})
+
+	// Init the LRU page cache
+	if config.PageCache.Enabled {
+		pageCache = golanglru2.NewLRU[PageCacheKey,PageCacheEntry](config.PageCache.MaxEntries, nil, time.Duration(config.PageCache.CacheDuration) * time.Second)
+	}
 }
 
 func initStats() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -221,9 +221,7 @@ func initWeb3protocolClient() {
 	web3protocolClient.Logger.SetFormatter(&log.TextFormatter{TimestampFormat: "2006-01-02 15:04:05", FullTimestamp: true})
 
 	// Init the LRU page cache
-	if config.PageCache.Enabled {
-		pageCache = golanglru2.NewLRU[PageCacheKey,PageCacheEntry](config.PageCache.MaxEntries, nil, time.Duration(config.PageCache.CacheDuration) * time.Second)
-	}
+	pageCache = golanglru2.NewLRU[PageCacheKey,PageCacheEntry](config.PageCache.MaxEntries, nil, time.Duration(config.PageCache.CacheDuration) * time.Second)
 }
 
 func initStats() {

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -280,10 +280,17 @@ func handle(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// Add the cache entry
-		pageCache.Add(PageCacheKey{
+		pageCacheKey := PageCacheKey{
 			Web3Url: web3Url,
 			AcceptEncodingHeader: req.Header.Get("Accept-Encoding"),
-		}, newCacheEntry)
+		}
+		pageCache.Add(pageCacheKey, newCacheEntry)
+
+		log.WithFields(log.Fields{
+			"domain": "web3urlGateway",
+			"etag": newCacheEntry.ETag,
+			"vary-headers": pageCacheKey.AcceptEncodingHeader,
+		}).Infof("Added page cache entry for %s", web3Url)
 	}
 
 	// Stats

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -266,6 +266,8 @@ func handle(w http.ResponseWriter, req *http.Request) {
 
 	// Save the cache entry
 	if willCacheResponse {
+		cacheResponseWriter.Flush()
+
 		newCacheEntry := PageCacheEntry{
 			ETag: w.Header().Get("ETag"),
 			HttpCode: fetchedWeb3Url.HttpCode,

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -8,6 +8,16 @@ HomePage = "/home.w3q/"
 CORS = "*" # list of domains from which to accept cross origin requests (browser enforced)
 defaultChain = 0
 
+# Page cache configuration
+# Ensure you have maxEntries * maxEntrySize available RAM
+[pageCache]
+enabled = true
+# Max number of entries in the cache. 0 means: default value of 1000 used
+maxEntries = 1000
+# Max size of an entry in the cache in bytes.
+maxEntrySize = 1000000 # 1MB
+# Page cache TTL in seconds. 0 means: unlimited
+cacheDuration = 86400 # 1 day
 
 # default chain for supported domain
 [nsDefaultChains]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -8,7 +8,7 @@ HomePage = "/home.w3q/"
 CORS = "*" # list of domains from which to accept cross origin requests (browser enforced)
 defaultChain = 0
 
-# Page cache configuration
+# Page cache : Standard HTTP caching and a list of immutable URLs
 # Ensure you have maxEntries * maxEntrySize available RAM
 [pageCache]
 enabled = true
@@ -18,6 +18,9 @@ maxEntries = 1000
 maxEntrySize = 1000000 # 1MB
 # Page cache TTL in seconds. 0 means: unlimited
 cacheDuration = 86400 # 1 day
+# A list of web3:// regexp URLs that are manually marked as immutable and can be cached indefinitely
+# Example : [ "web3://0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6:31337/detailedToken/.*" ]
+immutableUrlRegexps = []
 
 # default chain for supported domain
 [nsDefaultChains]

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.12.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.3
+	github.com/web3-protocol/web3protocol-go v0.2.5
 	golang.org/x/net v0.16.0
 )
 
@@ -52,7 +53,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
-	github.com/sirupsen/logrus v1.9.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.5
+	github.com/web3-protocol/web3protocol-go v0.2.6
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -497,6 +497,8 @@ github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003071313-a51e751044ab h1
 github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003071313-a51e751044ab/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
 github.com/web3-protocol/web3protocol-go v0.2.5 h1:/3EHlvPqiCCGsUElWZJI/4Ly/Bv+xwq/T3OT3IVS9YU=
 github.com/web3-protocol/web3protocol-go v0.2.5/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
+github.com/web3-protocol/web3protocol-go v0.2.6 h1:5qVKDqoAqbULqCZMY8qsQgqmlli71vYmF2HFcBWZT7Y=
+github.com/web3-protocol/web3protocol-go v0.2.6/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
@@ -400,6 +402,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -483,6 +487,16 @@ github.com/web3-protocol/web3protocol-go v0.2.2 h1:JHRSTXiIirogHxvHTwnM0XgJolyYe
 github.com/web3-protocol/web3protocol-go v0.2.2/go.mod h1:0sL433yN4XUKVfZSMQIal+m3vTovLpcsiuvteVJ83QY=
 github.com/web3-protocol/web3protocol-go v0.2.3 h1:EpgiROKkcIDV7MsE/bSqgdX2ogvrYT0g66NpPIJwWes=
 github.com/web3-protocol/web3protocol-go v0.2.3/go.mod h1:zDrTDbmVmNtY7x/ZZ8Wo9uBn/51aKNzd3OUoqv48BsE=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003061233-60baf0f6e550 h1:ttUxQVAA7pD/DCZdnDmlpAFpUibBsyLgcgqF1AIorVE=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003061233-60baf0f6e550/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003064005-2e54637f05c0 h1:PB6bqn4LSSPUH0Plug3fi80aP6B73v6Rc0oDC+UhFVc=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003064005-2e54637f05c0/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003065503-9f381ae1347d h1:Y5ekNwiwUEOC1FYEgur80mXdHaDPLhKsosxFkEMtMVc=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003065503-9f381ae1347d/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003071313-a51e751044ab h1:gQehxcIp8XVRmneFePKa8pulxVH6acUqlgMnEyPsXlE=
+github.com/web3-protocol/web3protocol-go v0.2.5-0.20241003071313-a51e751044ab/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
+github.com/web3-protocol/web3protocol-go v0.2.5 h1:/3EHlvPqiCCGsUElWZJI/4Ly/Bv+xwq/T3OT3IVS9YU=
+github.com/web3-protocol/web3protocol-go v0.2.5/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

This PR add support for caching of 2 types.
The aim of caching is to reduce RPC calls to the RPC providers.

The first type of caching is easy : it is a config entry `pageCache.immutableUrlRegexps` in which we declare a list of URLs we know are immutable. So the first time a page is loaded from RPC, then the result is saved in cache, and will be served from cache for later calls.

The second type of caching is a partial implementation of standard proxy HTTP caching : If we visualize web3url-gateway being a proxy, and the web3protocol-go library being a remote server for which we proxy : we implement standard HTTP caching based on ETag.
The mechanism is basically : 

- Request arrive
- We check if we have it in cache
- If the request has no `If-None-Match` cache invalidation header, and we have it in cache, then we inject an `If-None-Match: <ETag stored in cache>`, and we mark that it was manually injected
- We forward the request to web3protocol-go
- If the request response is a 304 (Not modified), and we manually injected `If-None-Match` : we return the cached request response and we stop here.
- If the request response is a 200, and it has an ETag, then we save the request response in the cache
- If the request response is a 200, and it has no ETag, and there was a page cache : we delete the page cache entry
- We forward the request response to the client

So this is basically standard partial HTTP caching. The cache is a LRU cache that can be configured (max nb of entries, max size of entries, TTL).

The more interesting part is inside an update of web3protocol-go, which implements ERC-7774 ( https://github.com/ethereum/ERCs/pull/652 -- a bit of work still needed), which allows resource request mode websites to send cache invalidation events. That way, the web3protocol-go listen for events, and can send HTTP code 200 or 304 (Not modified). The  most important part is : as long as the content is not modified, a 304 (Not modified) response will not make a RPC call.

Final conclusion : for an homepage I was working on, it was making 16 eth_call RPC calls.
After I implemented ERC-7774 on web3protocol-go, and the HTTP cache in web3url-gateway, it was reduced to 2 eth_call RPC calls. After I added the immutable URL caching system in web3url-gateway (in which I cache some auto mode URLs), it is now reduced to 0 eth_call RPC calls!

So now web3url-gateway can handle heavy traffic on a `web3://` website implementing ERC-7774.