### PR TITLE
Cache clearing scenario: Now cache clear for all non-304 HTTP code instead of only 200.

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -342,9 +342,10 @@ func handle(w http.ResponseWriter, req *http.Request) {
 			logFields["etag"] = newCacheEntry.ETag
 		}
 		log.WithFields(logFields).Infof("Added page cache entry for %s", web3Url)
-	// If we got a HTTP 200 code, we don't cache the page, there was previously a cache entry,
-	// and the cache entry was of type PageCacheEntryTypeHttpCaching, we remove it from the cache
-	} else if fetchedWeb3Url.HttpCode == 200 && cacheEntryPresent && cacheEntry.Type == PageCacheEntryTypeHttpCaching {
+	// If we know we will not cache this page, and we got a HTTP code different than 304 (Not modified), 
+	// and if there was previously a cache entry of type PageCacheEntryTypeHttpCaching, 
+	// we remove it from the cache
+	} else if fetchedWeb3Url.HttpCode != 304 && cacheEntryPresent && cacheEntry.Type == PageCacheEntryTypeHttpCaching {
 		pageCache.Remove(pageCacheKey)
 		log.WithFields(log.Fields{
 			"domain": "web3urlGateway",


### PR DESCRIPTION
Hi!

As discussed in last PR (https://github.com/ethstorage/web3url-gateway/pull/35 )
Now, in the cache clearing scenario: we no longer require a HTTP 200.

Scenario now covered : 
- Browser A request /path , web3protocol-go returns a body with an ETag, web3url-gateway caches it.
- Browser A request /path again, with If-None-Match, web3url-gateway forwards the call to web3protocol-go, which returns 304. The 304 is sent back to the browser.
- The owner of the website makes a modification : he now makes that /path return 404, because he wants to unpublish the page.
- - Browser A request /path again, with If-None-Match, web3url-gateway forwards the call to web3protocol-go, which returns 404 with no ETag. The cache is cleared in web3url-gateway, and the response is forwarded to browser.

This is now very broad. There could potentially be some advanced edges cases with some HTTP codes where we may not want to clear the cache, but let's keep it simple for now, and to be on the safe side, it is better to clear cache too much than not enough.