### PR TITLE
Bump web3protocol-go to v0.2.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.6
+	github.com/web3-protocol/web3protocol-go v0.2.7
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -499,6 +499,8 @@ github.com/web3-protocol/web3protocol-go v0.2.5 h1:/3EHlvPqiCCGsUElWZJI/4Ly/Bv+x
 github.com/web3-protocol/web3protocol-go v0.2.5/go.mod h1:2v5SgCx6n3ABsomkwbuT/mkRT405Z6z9UATHwaIALzc=
 github.com/web3-protocol/web3protocol-go v0.2.6 h1:5qVKDqoAqbULqCZMY8qsQgqmlli71vYmF2HFcBWZT7Y=
 github.com/web3-protocol/web3protocol-go v0.2.6/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.7 h1:qQHRT3/EveI/r2gnGG5U30Us3BHtw0SfRWyQZSud4Qw=
+github.com/web3-protocol/web3protocol-go v0.2.7/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

Previously I added support for [ERC-7774](https://github.com/ethereum/ERCs/pull/652/files) with which a page can indicate that EVM events will be emitted when the page change.

I [have added](https://github.com/ethereum/ERCs/pull/652/commits/591aa10feabf9591c1b44096e79e40aab193a88f) in the ERC the possibility for a page to indicate that the EVM events can come from another contract that the one serving the page, and that the path argument it listen for could be different.

The reason : I expect a lot of "proxy" patterns, where a smartcontract will proxy pages from another contract.
Example: Someone publish an web3:// smart contract (e.g. a wallet app), and user can make their own versions by making a Simple proxy contract to the base app. Here, the user website page should listen for EVM contract in the base contract.

By bumping web3protocol-go to v0.2.7, we can now do that, and ocweb.eth use that for various parts. 

Commit in web3protocol-go: https://github.com/web3-protocol/web3protocol-go/commit/dfe910b39e7cd88434217beb489478926182bf4c