### PR TITLE
Bump web3protocol-go to v0.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.7
+	github.com/web3-protocol/web3protocol-go v0.2.8
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,8 @@ github.com/web3-protocol/web3protocol-go v0.2.6 h1:5qVKDqoAqbULqCZMY8qsQgqmlli71
 github.com/web3-protocol/web3protocol-go v0.2.6/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.7 h1:qQHRT3/EveI/r2gnGG5U30Us3BHtw0SfRWyQZSud4Qw=
 github.com/web3-protocol/web3protocol-go v0.2.7/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.8 h1:+EpVZH/YZaj55ZT2pgaYdem7HxD/PZQlq4BDgsCL79k=
+github.com/web3-protocol/web3protocol-go v0.2.8/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

In the context of the latest change regarding ERC-7774 and caching, this change optimize the RPC call usage in a low traffic situation.
Indeed, in order to track EVM events, it will regularly poll the blockchain for them. So roughly, if the traffic is no more than around 1 page view every 2 minutes, then the tracking system will cost more in RPC calls.

The solution, implemented in the new version, is simply to desactivate the tracking when there has been no use of the cache in the last XX minutes (here, put at 10).

So now, in case of traffic burst, caching will be active, and total RPC usage will be the tracker usage (1 call per 12s), and when there is no traffic, the cache tracker will be desactivated, and there will be no RPC usage.

Thanks!