### PR TITLE
Bump web3protocol-go to v0.2.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.8
+	github.com/web3-protocol/web3protocol-go v0.2.9
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/web3-protocol/web3protocol-go v0.2.7 h1:qQHRT3/EveI/r2gnGG5U30Us3BHtw
 github.com/web3-protocol/web3protocol-go v0.2.7/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.8 h1:+EpVZH/YZaj55ZT2pgaYdem7HxD/PZQlq4BDgsCL79k=
 github.com/web3-protocol/web3protocol-go v0.2.8/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.9 h1:2PrXI9cbDhzyEibU2+nR7mNUpF66tW2vlefW4y8pjNY=
+github.com/web3-protocol/web3protocol-go v0.2.9/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

This fix the following reported issue by @0x_qz : After uninstalling an OCWebsite plugin, the pages were still cached.

Reason : The proposed ERC-7774 propose a cache clearing for the "*" path, so that all paths from a website is cleared. The contract was correctly emitting this on plugin uninstallation, but web3protocol-go had not implemented that yet.

Correction : The v0.2.9 version of web3protocol-go now implement the cache clearing for the "*" path.

Thanks!