### PR TITLE
Bump web3protocol-go to v0.2.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.9
+	github.com/web3-protocol/web3protocol-go v0.2.11
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -505,6 +505,8 @@ github.com/web3-protocol/web3protocol-go v0.2.8 h1:+EpVZH/YZaj55ZT2pgaYdem7HxD/P
 github.com/web3-protocol/web3protocol-go v0.2.8/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.9 h1:2PrXI9cbDhzyEibU2+nR7mNUpF66tW2vlefW4y8pjNY=
 github.com/web3-protocol/web3protocol-go v0.2.9/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.11 h1:6SpcSBbxoxgljnpO/AKO3lUOV/rY60TyCw1SRMtHfEM=
+github.com/web3-protocol/web3protocol-go v0.2.11/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

I have made a small change to web3protocol-go to make ERC-7774 caching handle temporary failure of RPC.

Demo : 
https://0x6dde8903cd77aacf07972ff44f7eac13d816e043.10.web3gateway.dev/
This website have an very large number of JS/CSS dependencies.
At first load, the site breaks, as only ~75% of assets loads, and then the RPC answers 429 Too many connections.

What we expect is that, since we have ERC-7774 caching, you load again, and it will only try to load the last 25% assets, and after one or two tries, it works fully. Then you can keep on refreshing the website, it will work, because everything is cached.

But right now it is not what is happens, what is happening now is : 
- A user loads https://0x6dde8903cd77aacf07972ff44f7eac13d816e043.10.web3gateway.dev/
- The RPC is overwhelmed, return 429 Too many connections
- The ERC-7774 event check worker (that listen the blockchain for cache clearing events) fail to fetch the events due to the RPC returning 429, and stop the whole ERC-7774 mechanism.
- The user load again the page, the ERC-7774 mechanism restart again from scratch, and we are in a loop.

So the change made to v0.2.11 is pretty basic : In the event check worker, allow RPC failure for up to 1 minute. After 1 minute of RPC failure, shutdown the ERC-7774 mechanism. (We cannot wait for too long, or we will serve potentially old stale content). This is a short term solution for medium traffic.

For later, a long term additional thing to do will be : Have a separate RPC endpoint for the ERC-7774 mechanism; so that even if case of heavy traffic over multiple uncached websites that keep on crashing the RPC, the ERC-7774 mechanism can keep on living, and the cached websites will be served even if the RPC is crashed.

The web3protocol-go commit is : https://github.com/web3-protocol/web3protocol-go/commit/136c8e1a5531649db0bfdac0db50a55471452be7