### PR TITLE
Bump web3protocol-go: Better graceful handling of 429, group processing of identical requests.

### DIFF
--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -50,6 +50,8 @@ type NameServiceInfo struct {
 type ChainConfig struct {
 	ChainID  int
 	RPC      string
+	RPCMaxConcurrentRequests int
+	SystemRPC string
 	NSConfig map[string]NameServiceInfo
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -164,7 +164,11 @@ func initWeb3protocolClient() {
 		// Config the chain
 		web3pChainConfig := web3protocol.ChainConfig{
 			ChainId:            chainConfig.ChainID,
-			RPC:                chainConfig.RPC,
+			RPC: web3protocol.ChainRPCConfig {
+				Url: chainConfig.RPC,
+				MaxConcurrentRequests: chainConfig.RPCMaxConcurrentRequests,
+			},
+			SystemRPC: chainConfig.SystemRPC,
 			DomainNameServices: map[web3protocol.DomainNameService]web3protocol.DomainNameServiceChainConfig{},
 		}
 

--- a/cmd/server/sub_protocols.go
+++ b/cmd/server/sub_protocols.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -17,12 +18,12 @@ import (
 func handleOrdinals(w http.ResponseWriter, req *http.Request, path string) {
 	temp := strings.Split(path, "/")
 	if len(temp) != 3 || (temp[1] != "txid" && temp[1] != "number") {
-		respondWithErrorPage(w, &web3protocol.ErrorWithHttpCode{http.StatusBadRequest, "invalid ordinals query"})
+		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: errors.New("invalid ordinals query")})
 		return
 	}
 	ocontent, otype, oerr := getInscription(temp[2])
 	if oerr != nil {
-		respondWithErrorPage(w, &web3protocol.ErrorWithHttpCode{http.StatusBadRequest, oerr.Error()})
+		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: oerr})
 		return
 	}
 	if otype != "" {
@@ -30,7 +31,7 @@ func handleOrdinals(w http.ResponseWriter, req *http.Request, path string) {
 	}
 	_, e := w.Write(ocontent)
 	if e != nil {
-		respondWithErrorPage(w, &web3protocol.ErrorWithHttpCode{http.StatusBadRequest, e.Error()})
+		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: e})
 		return
 	}
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -80,6 +80,12 @@ immutableUrlRegexps = []
     [chainConfigs.1]
     "ChainID" = 1
     "RPC" = "https://mainnet.infura.io/v3/************"
+    # The maximum number of concurrent requests to the RPC. Default is 5, tuning this may
+    # help to prevent too much 429 Too Many Connection errors.
+    "RPCMaxConcurrentRequests" = 5
+    # System RPC is the RPC used by system workers (such as ERC-7774 cache event tracking)
+    # It should be different of the main RPC. If empty, will use the main RPC.
+    "SystemRPC" = "https://another.rpc"
     [chainConfigs.1.NSConfig."eth"]
         "NSType" = "ens"
         "NSAddr" = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.11
+	github.com/web3-protocol/web3protocol-go v0.2.13
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,10 @@ github.com/web3-protocol/web3protocol-go v0.2.9 h1:2PrXI9cbDhzyEibU2+nR7mNUpF66t
 github.com/web3-protocol/web3protocol-go v0.2.9/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.11 h1:6SpcSBbxoxgljnpO/AKO3lUOV/rY60TyCw1SRMtHfEM=
 github.com/web3-protocol/web3protocol-go v0.2.11/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.12 h1:jb5kTHsampJ7bEimav2RLBdmucsMdtPyb8Rf0mfU2io=
+github.com/web3-protocol/web3protocol-go v0.2.12/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.13 h1:Xsw0KcgUGLua4jUsuz0bcqb5ZxyAJqgv1X78E0mOZj0=
+github.com/web3-protocol/web3protocol-go v0.2.13/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

This is a big one : 
- Now handling RPC 429 Too Many connections by waiting for them to be available again, with a timeout of 30s.
- A maximum number of concurrent requests are enforced per RPC
- There is the possibility to specify a "System RPC" per chain, different than the same one. This one is used for system worker (such as the ERC-7774 cache event checking), so that when the main RPC breaks, the one used by the workers still run. Much better, because if the ERC-7774 worker fails too long to make RPC calls, it clear all cache and desactivate itself.
- Multiple request for the same URL / specific HTTP headers are now grouped : if X person calls for the same thing, it will be processed only once.
- Fix an issue where, when the RPC was failing during resolve mode determination, it would determine that a website was auto mode even though it was not. (Due to the code previously not differentiating an "execution revert" error from a RPC failure)

On the config side, 2 new fields after RPC: 
```toml
    [chainConfigs.1]
    "ChainID" = 1
    "RPC" = "https://mainnet.infura.io/v3/************"
    # The maximum number of concurrent requests to the RPC. Default is 5, tuning this may
    # help to prevent too much 429 Too Many Connection errors.
    "RPCMaxConcurrentRequests" = 5
    # System RPC is the RPC used by system workers (such as ERC-7774 cache event tracking)
    # It should be different of the main RPC. If empty, will use the main RPC.
    "SystemRPC" = "https://another.rpc"
```

When updating web3gateway.dev, could you: 
- Add a "SystemRPC" field for Optimism, and use the current Optimsl Infura RPC,
- Replace the "RPC" field for Optimism, put "https://mainnet.optimism.io" (much more efficient)

Thanks a lot!