### PR TITLE
Prevent DDoS on Autocert requests

### DIFF
--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -140,7 +140,7 @@ func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	// validate the server name
 	_, _, er := handleSubdomain(hello.ServerName, "")
 	if er != nil {
-		log.Errorf("Invalid subdomain: %s", hello.ServerName, er)
+		log.Errorf("Invalid subdomain: %s, %w", hello.ServerName, er)
 		return nil, &web3protocol.Web3ProtocolError{HttpCode: http.StatusBadRequest, Err: er}
 	}
 

--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -140,7 +140,7 @@ func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	// validate the server name
 	_, _, er := handleSubdomain(hello.ServerName, "")
 	if er != nil {
-		log.Errorf("Invalid subdomain: %s, %w", hello.ServerName, er)
+		log.Errorf("Invalid subdomain: %s", hello.ServerName)
 		return nil, &web3protocol.Web3ProtocolError{HttpCode: http.StatusBadRequest, Err: er}
 	}
 

--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -134,8 +134,16 @@ func tryFindSystemCertificate(domain string) (*tls.Certificate, error) {
 }
 
 func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	log.Warnf("GetCertificate: %s\n", hello.ServerName)
 	if cert, err := tryFindSystemCertificate(hello.ServerName); err == nil && cert != nil {
+		log.Warnf("found system certificate: %s\n", hello.ServerName)
 		return cert, nil
 	}
-	return certManager.GetCertificate(hello)
+	cert, err := certManager.GetCertificate(hello)
+	if err != nil {
+		log.Errorf("autocert: get certificate error: %v\n", err)
+		return nil, err
+	}
+	log.Warnf("autocert: get certificate: %s\n", hello.ServerName)
+	return cert, nil
 }

--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -136,23 +136,23 @@ func tryFindSystemCertificate(domain string) (*tls.Certificate, error) {
 }
 
 func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	log.Warnf("GetCertificate: %s\n", hello.ServerName)
-	// validate the server name
+	log.Infof("TLS: getting certificate for %s\n", hello.ServerName)
+	// pre-check the server name
 	_, _, er := handleSubdomain(hello.ServerName, "/")
 	if er != nil {
-		log.Errorf("Invalid subdomain: %s", hello.ServerName)
+		log.Errorf("Invalid subdomain: %s\n", hello.ServerName)
 		return nil, &web3protocol.Web3ProtocolError{HttpCode: http.StatusBadRequest, Err: er}
 	}
 
 	if cert, err := tryFindSystemCertificate(hello.ServerName); err == nil && cert != nil {
-		log.Warnf("found system certificate: %s\n", hello.ServerName)
+		log.Infof("Found system certificate: %s\n", hello.ServerName)
 		return cert, nil
 	}
 	cert, err := certManager.GetCertificate(hello)
 	if err != nil {
-		log.Errorf("autocert: get certificate error: %v\n", err)
+		log.Errorf("Autocert: get certificate error: %v\n", err)
 		return nil, err
 	}
-	log.Warnf("autocert: get certificate: %s\n", hello.ServerName)
+	log.Infof("Autocert: got certificate: %s\n", hello.ServerName)
 	return cert, nil
 }

--- a/cmd/server/autossl.go
+++ b/cmd/server/autossl.go
@@ -138,7 +138,7 @@ func tryFindSystemCertificate(domain string) (*tls.Certificate, error) {
 func GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	log.Warnf("GetCertificate: %s\n", hello.ServerName)
 	// validate the server name
-	_, _, er := handleSubdomain(hello.ServerName, "")
+	_, _, er := handleSubdomain(hello.ServerName, "/")
 	if er != nil {
 		log.Errorf("Invalid subdomain: %s", hello.ServerName)
 		return nil, &web3protocol.Web3ProtocolError{HttpCode: http.StatusBadRequest, Err: er}

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -464,13 +464,7 @@ func handleSubdomain(host string, path string) (p string, useSubdomain bool, err
 
 		// Hostname: If [host]:[chain-short-name] then [host]:[chain-id]
 		full := hostChangeChainShortNameToId(hostParts[0] + ":" + hostParts[1])
-
-		pp := strings.Split(path, "/")
-		if len(pp) > 1 && (strings.HasSuffix(pp[1], ".w3q") || strings.HasSuffix(pp[1], ".eth")) {
-			p = strings.Replace(path, pp[1], full, 1)
-		} else {
-			p = "/" + full + path
-		}
+		p = "/" + full + path
 		useSubdomain = true
 	}
 


### PR DESCRIPTION
Addressing autocerts rate limits issue mentioned in https://github.com/ethstorage/web3url-gateway/issues/46.

Update on `GetCertificate()` to pre-check the server name by using `handleSubdomain()` to prevent continuous invalid URL requests.

Note: due to fmt issue, the only real change in `cmd/server/protocol.go`  is line 489, which fixes the index out of range.