### PR TITLE
Limit concurrent requests

### DIFF
--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -186,7 +186,7 @@ func hostChangeChainShortNameToId(host string) string {
 	return hostParts[0] + ":" + chainId
 }
 
-const maxConcurrentRequests = 100 // Maximum number of concurrent requests
+const maxConcurrentRequests = 1 // Maximum number of concurrent requests
 var semaphore = make(chan struct{}, maxConcurrentRequests)
 
 func requestLimiter(next http.Handler) http.Handler {

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -189,6 +189,8 @@ func hostChangeChainShortNameToId(host string) string {
 
 func requestLimiter(next http.Handler) http.Handler {
 	var semaphore = make(chan struct{}, config.RequestLimit)
+	log.Infof("Request limit: %v\n", config.RequestLimit)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case semaphore <- struct{}{}: // Acquire a slot

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -33,6 +33,7 @@ type Web3Config struct {
 	NSDefaultChains map[string]int
 	Name2Chain      map[string]int
 	ChainConfigs    map[int]ChainConfig
+	RequestLimit    int
 }
 
 type PageCacheConfig struct {
@@ -186,10 +187,8 @@ func hostChangeChainShortNameToId(host string) string {
 	return hostParts[0] + ":" + chainId
 }
 
-const maxConcurrentRequests = 1 // Maximum number of concurrent requests
-var semaphore = make(chan struct{}, maxConcurrentRequests)
-
 func requestLimiter(next http.Handler) http.Handler {
+	var semaphore = make(chan struct{}, config.RequestLimit)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case semaphore <- struct{}{}: // Acquire a slot

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -95,15 +95,13 @@ func initConfig() {
 	if cors.set {
 		config.CORS = cors.value
 	}
-	if requestLimit.set {
-		limit, err := strconv.Atoi(requestLimit.value)
-		if err != nil {
-			log.Fatalf("Unable to parse %v as an integer\n", requestLimit.value)
-			return
-		}
-		config.RequestLimit = limit
+	limit, err := strconv.Atoi(requestLimit.value)
+	if err != nil {
+		log.Fatalf("Unable to parse %v as an integer\n", requestLimit.value)
+		return
 	}
-	log.Infof("Request limit: %v\n", config.RequestLimit)
+	config.RequestLimit = limit
+
 	// Page cache size: not use the default of unlimited, will only end in crashed servers
 	if config.PageCache.MaxEntries == 0 {
 		config.PageCache.MaxEntries = 1000

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,7 +96,7 @@ func initConfig() {
 		config.CORS = cors.value
 	}
 	if requestLimit.set {
-		limit, err := strconv.Atoi(defaultChain.value)
+		limit, err := strconv.Atoi(requestLimit.value)
 		if err != nil {
 			log.Fatalf("Unable to parse %v as an integer\n", requestLimit.value)
 			return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -95,12 +95,14 @@ func initConfig() {
 	if cors.set {
 		config.CORS = cors.value
 	}
-	limit, err := strconv.Atoi(requestLimit.value)
-	if err != nil {
-		log.Fatalf("Unable to parse %v as an integer\n", requestLimit.value)
-		return
+	if requestLimit.set {
+		limit, err := strconv.Atoi(requestLimit.value)
+		if err != nil {
+			log.Fatalf("Invalid requestLimit: %v\n", requestLimit.value)
+			return
+		}
+		config.RequestLimit = limit
 	}
-	config.RequestLimit = limit
 
 	// Page cache size: not use the default of unlimited, will only end in crashed servers
 	if config.PageCache.MaxEntries == 0 {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -257,10 +257,11 @@ func main() {
 		}
 	})
 
+	limitedHandler := requestLimiter(http.DefaultServeMux)
 	if config.RunAsHttp {
 		log.Infof("Serving on http://localhost:%v\n", config.ServerPort)
 		log.Info("Running server in unsecure mode...")
-		err := http.ListenAndServe(":"+config.ServerPort, nil)
+		err := http.ListenAndServe(":"+config.ServerPort, limitedHandler)
 		if err != nil {
 			log.Fatalf("Cannot start server: %v\n", err)
 			return
@@ -275,9 +276,10 @@ func main() {
 				MinVersion:     tls.VersionTLS12,
 			},
 			MaxHeaderBytes: 32 << 20,
+			Handler:        limitedHandler,
 		}
 
-		go http.ListenAndServe(":http", certManager.HTTPHandler(nil)) // 支持 http-01
+		go http.ListenAndServe(":http", certManager.HTTPHandler(nil)) // support http-01
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			log.Fatalf("Cannot start server: %v\n", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,7 @@ var (
 	defaultChain                  = stringFlags{value: "1"}
 	homePage                      = stringFlags{value: "/web3url.eth/"}
 	cors                          = stringFlags{value: "*"}
+	requestLimit                  = stringFlags{value: "200"}
 	nsInfos, chainInfos, nsChains arrayFlags
 	config                        Web3Config
 	web3protocolClient            *web3protocol.Client
@@ -57,6 +58,7 @@ func initConfig() {
 	flag.Var(&defaultChain, "defaultChain", "default chain id")
 	flag.Var(&homePage, "homePage", "home page address")
 	flag.Var(&cors, "cors", "comma separated list of domains from which to accept cross origin requests")
+	flag.Var(&requestLimit, "requestLimit", "max number of concurrent requests")
 	flag.Parse()
 
 	// read from config file
@@ -93,6 +95,15 @@ func initConfig() {
 	if cors.set {
 		config.CORS = cors.value
 	}
+	if requestLimit.set {
+		limit, err := strconv.Atoi(defaultChain.value)
+		if err != nil {
+			log.Fatalf("Unable to parse %v as an integer\n", requestLimit.value)
+			return
+		}
+		config.RequestLimit = limit
+	}
+	log.Infof("Request limit: %v\n", config.RequestLimit)
 	// Page cache size: not use the default of unlimited, will only end in crashed servers
 	if config.PageCache.MaxEntries == 0 {
 		config.PageCache.MaxEntries = 1000

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -7,6 +7,7 @@ KeyFile = ""
 HomePage = "/web3url.eth/"
 CORS = "*" # list of domains from which to accept cross origin requests (browser enforced)
 defaultChain = 0
+requestLimit = 200 # max number of concurrent requests
 
 # Page cache : Standard HTTP caching and a list of immutable URLs
 # Ensure you have maxEntries * maxEntrySize available RAM

--- a/it/scripts/check-links.mjs
+++ b/it/scripts/check-links.mjs
@@ -9,7 +9,8 @@ async function checkLink(url) {
     });
     console.log(url, ":", response.statusText);
     if (!response.ok) {
-      throw new Error(`HTTP status ${response.status}`);
+      const errorMessage = await response.text();
+      throw new Error(`HTTP status ${response.status}: ${errorMessage}`);
     }
     return { url, status: response.status, success: true };
   } catch (error) {


### PR DESCRIPTION
Addressing https://github.com/ethstorage/web3url-gateway/issues/55, this PR adds a middleware using semaphore to limit concurrent requests.

The default limit is 200 which can be configured in either config.toml or shell flag.

Tests have been done with `it/scripts/check-links.mjs`, showing that when `requestLimit` is set, the links that exceed the limit return 503: `Too many requests, please try again later.`