### PR TITLE
Extend timeout 

### DIFF
--- a/it/scripts/check-links.mjs
+++ b/it/scripts/check-links.mjs
@@ -5,7 +5,7 @@ async function checkLink(url) {
   try {
     const response = await fetch(url, {
       agent: new https.Agent({ rejectUnauthorized: false }),
-      signal: AbortSignal.timeout(50000),
+      signal: AbortSignal.timeout(100000),
     });
     console.log(url, ":", response.statusText);
     if (!response.ok) {

--- a/it/scripts/check-links.mjs
+++ b/it/scripts/check-links.mjs
@@ -5,7 +5,7 @@ async function checkLink(url) {
   try {
     const response = await fetch(url, {
       agent: new https.Agent({ rejectUnauthorized: false }),
-      signal: AbortSignal.timeout(30000),
+      signal: AbortSignal.timeout(50000),
     });
     console.log(url, ":", response.statusText);
     if (!response.ok) {


### PR DESCRIPTION
to prevent bad link error emails caused by slow rpcs.