### PR TITLE
Improved gateway integration in the HTML pages

### DIFF
--- a/cmd/server/html.patch
+++ b/cmd/server/html.patch
@@ -30,16 +30,12 @@
           subDomains.push(urlMainParts.chainId)
         }
         else {
-          // gateway = "w3eth.io"
           subDomains.push(1);
         }
       }
       // It is a domain name
       else {
-        // ENS domains on mainnet have a shortcut
         if(urlMainParts.hostname.endsWith('.eth') && urlMainParts.chainId === undefined) {
-          // gateway = "w3eth.io"
-          // subDomains.push(urlMainParts.hostname.slice(0, -4))
           subDomains.push(urlMainParts.hostname)
           subDomains.push(1)
         }
@@ -111,6 +107,7 @@
       {element: HTMLSourceElement, attrName: 'src'}, // <source>
       {element: HTMLEmbedElement, attrName: 'src'}, // <embed>
       {element: HTMLInputElement, attrName: 'src'}, // <input type="image">
+      {element: HTMLObjectElement, attrName: 'data'}, // <object>
     ];
     elementsWithUrlAttr.forEach(function(elementWithUrlAttr) {
       const originalAttrSetter = Object.getOwnPropertyDescriptor(elementWithUrlAttr.element.prototype, elementWithUrlAttr.attrName).set;

--- a/cmd/server/html.patch
+++ b/cmd/server/html.patch
@@ -96,31 +96,33 @@
 
     // All tags with a attribute that can get an URL: override the setting of the attribute to convert web3:// URLs into gateway URLs
     const elementsWithUrlAttr = [
-      {element: HTMLAnchorElement, attrName: 'href'}, // <a>
-      {element: HTMLLinkElement, attrName: 'href'}, // <link>
-      {element: HTMLAreaElement, attrName: 'href'}, // <area>
-      {element: HTMLImageElement, attrName: 'src'}, // <img>
-      {element: HTMLScriptElement, attrName: 'src'}, // <script>
-      {element: HTMLIFrameElement, attrName: 'src'}, // <iframe>
-      // {tag: HTMLAudioElement, attr: 'src'}, // <audio>
-      // {tag: HTMLVideoElement, attr: 'src'}, // <video>
-      {element: HTMLSourceElement, attrName: 'src'}, // <source>
-      {element: HTMLEmbedElement, attrName: 'src'}, // <embed>
-      {element: HTMLInputElement, attrName: 'src'}, // <input type="image">
-      {element: HTMLObjectElement, attrName: 'data'}, // <object>
+      {tagName: 'a', attrName: 'href'}, // <a>
+      {tagName: 'link', attrName: 'href'}, // <link>
+      {tagName: 'area', attrName: 'href'}, // <area>
+      {tagName: 'img', attrName: 'src'}, // <img>
+      {tagName: 'script', attrName: 'src'}, // <script>
+      {tagName: 'iframe', attrName: 'src'}, // <iframe>
+      // {tagName: 'audio', attr: 'src'}, // <audio>
+      // {tagName: 'video', attr: 'src'}, // <video>
+      {tagName: 'source', attrName: 'src'}, // <source>
+      {tagName: 'embed', attrName: 'src'}, // <embed>
+      {tagName: 'input', attrName: 'src'}, // <input type="image">
+      {tagName: 'object', attrName: 'data'}, // <object>
     ];
+    // Override the setter of the attribute to convert web3:// URLs into gateway URLs
     elementsWithUrlAttr.forEach(function(elementWithUrlAttr) {
-      const originalAttrSetter = Object.getOwnPropertyDescriptor(elementWithUrlAttr.element.prototype, elementWithUrlAttr.attrName).set;
-      Object.defineProperty(elementWithUrlAttr.element.prototype, elementWithUrlAttr.attrName, {
+      const element = document.createElement(elementWithUrlAttr.tagName);
+      const originalAttrSetter = Object.getOwnPropertyDescriptor(element.constructor.prototype, elementWithUrlAttr.attrName).set;
+      Object.defineProperty(element.constructor.prototype, elementWithUrlAttr.attrName, {
         set: function(attrValue) {
           if(attrValue.startsWith('web3://')) {
             const convertedUrl = convertWeb3UrlToGatewayUrl(attrValue);
             if(convertedUrl == null) {
-              console.error("Gateway " + elementWithUrlAttr.element.name + " " + elementWithUrlAttr.attrName + " setter wrapper: Unable to convert web3:// URL: " + attrValue);
+              console.error("Gateway " + element.name + " " + elementWithUrlAttr.attrName + " setter wrapper: Unable to convert web3:// URL: " + attrValue);
               originalAttrSetter.call(this, attrValue);
               return;
             }
-            console.log('Gateway ' + elementWithUrlAttr.element.name + ' ' + elementWithUrlAttr.attrName + ' setter wrapper: Converted ' + attrValue + ' to ' + convertedUrl);
+            console.log('Gateway ' + element.name + ' ' + elementWithUrlAttr.attrName + ' setter wrapper: Converted ' + attrValue + ' to ' + convertedUrl);
             originalAttrSetter.call(this, convertedUrl);
           }
           else {
@@ -129,6 +131,38 @@
         }
       });
     });
+    // Added nodes to the DOM : convert web3:// URLs into gateway URLs
+    const observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        // Insertion of nodes with the src attribute (img, iframe, audio, ...)
+        if(mutation.type === 'childList') {
+          mutation.addedNodes.forEach(function(addedNode) {
+            // Ignore non-element nodes
+            if(addedNode.nodeType != 1) {
+              return;
+            }
+            // Find all nodes that have a web3:// URL in their attribute as defined in elementsWithUrlAttr
+            elementsWithUrlAttr.forEach(function(elementWithUrlAttr) {
+              const nodes = [...addedNode.querySelectorAll(elementWithUrlAttr.tagName + '[' + elementWithUrlAttr.attrName + '^="web3://"]')];
+              if(addedNode.tagName === elementWithUrlAttr.tagName && addedNode[elementWithUrlAttr.attrName].startsWith('web3://')) {
+                nodes.push(addedNode);
+              }
+              nodes.forEach(function(node) {
+                const targetUrl = node[elementWithUrlAttr.attrName];
+                const convertedUrl = convertWeb3UrlToGatewayUrl(targetUrl);
+                if(convertedUrl == null) {
+                  console.error("Gateway " + node.tagName + " injection wrapper: Unable to convert web3:// URL: " + targetUrl);
+                  return;
+                }
+                console.log('Gateway ' + node.tagName + ' injection wrapper: Converted ' + targetUrl + ' to ' + convertedUrl);
+                node[elementWithUrlAttr.attrName] = convertedUrl;
+              });
+            });
+          });
+        }
+      });
+    });
+    observer.observe(document.querySelector("body"), {childList: true, subtree: true});
 
   })();
 </script>

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -546,16 +546,23 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string) int {
 		}
 	}
 
-	// Look for the "<body>" tag, and insert the patch right after it
-	bodyTagIndex := strings.Index(string(alteredBuf), "<body>")
+	// Look for the "<body>" tag (which might have attributes), and insert the patch right after it
+	// Find the "<body" tag
+	bodyTagIndex := strings.Index(strings.ToLower(string(alteredBuf)), "<body")
 	if bodyTagIndex == -1 {
 		return n
 	}
-
-	// Insert the patch right after the "<body>" tag
+	// Find the closing '>' of the body tag
+	closingTagIndex := strings.Index(string(alteredBuf[bodyTagIndex:]), ">")
+	if closingTagIndex == -1 {
+		return n
+	}	
+	// Calculate the actual position of the closing '>' in the full buffer
+	closingTagIndex += bodyTagIndex + 1
+	// Insert the patch right after the closing '>' of the body tag
 	alteredBuf = append(
-		alteredBuf[:bodyTagIndex+len("<body>")],
-		append(htmlPatch, alteredBuf[bodyTagIndex+len("<body")+1:len(alteredBuf)]...)...)
+		alteredBuf[:closingTagIndex],
+		append(htmlPatch, alteredBuf[closingTagIndex:len(alteredBuf)]...)...)
 
 	// If contentEncoding is "gzip", then recompress the data
 	if contentEncoding == "gzip" {

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -158,6 +158,13 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	if cacheInvalidationHeadersSetFromCache && fetchedWeb3Url.HttpCode == 304 {
 		// Send the HTTP headers returned by the protocol
 		for httpHeaderName, httpHeaderValue := range cacheEntry.HttpHeaders {
+			// If header is "Location", and value is a web3:// URL, convert it to a gateway URL
+			if strings.ToLower(httpHeaderName) == "location" && strings.HasPrefix(httpHeaderValue, "web3://") {
+				newUrl, err := ConvertWeb3UrlToGatewayUrl(httpHeaderValue, rootGatewayHost)
+				if err == nil {
+					httpHeaderValue = newUrl
+				}
+			}
 			w.Header().Set(httpHeaderName, httpHeaderValue)
 		}
 		// Add a extra header indicating that it was served from cache
@@ -183,6 +190,13 @@ func handle(w http.ResponseWriter, req *http.Request) {
 
 	// Send the HTTP headers returned by the protocol
 	for httpHeaderName, httpHeaderValue := range fetchedWeb3Url.HttpHeaders {
+		// If header is "Location", and value is a web3:// URL, convert it to a gateway URL
+		if strings.ToLower(httpHeaderName) == "location" && strings.HasPrefix(httpHeaderValue, "web3://") {
+			newUrl, err := ConvertWeb3UrlToGatewayUrl(httpHeaderValue, rootGatewayHost)
+			if err == nil {
+				httpHeaderValue = newUrl
+			}
+		}
 		w.Header().Set(httpHeaderName, httpHeaderValue)
 	}
 	// Add a extra header indicating that it was not served from cache

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.14
+	github.com/web3-protocol/web3protocol-go v0.2.15
 	golang.org/x/net v0.16.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.15
+	github.com/web3-protocol/web3protocol-go v0.2.16
 	golang.org/x/net v0.16.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/web3-protocol/web3protocol-go v0.2.13
+	github.com/web3-protocol/web3protocol-go v0.2.14
 	golang.org/x/net v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,8 @@ github.com/web3-protocol/web3protocol-go v0.2.14 h1:ckILVqPZJeMo8e8g7em0yG5jQ2pz
 github.com/web3-protocol/web3protocol-go v0.2.14/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.15 h1:lY3PN5Ue6EPOgb3GZnoQGyz2T91h6lkmmxLKKctDb/0=
 github.com/web3-protocol/web3protocol-go v0.2.15/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.16 h1:OLTX3rZggWSgXUUMOILpC63KsTU2nXyI6P1tqoYX8UA=
+github.com/web3-protocol/web3protocol-go v0.2.16/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,8 @@ github.com/web3-protocol/web3protocol-go v0.2.12 h1:jb5kTHsampJ7bEimav2RLBdmucsM
 github.com/web3-protocol/web3protocol-go v0.2.12/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.13 h1:Xsw0KcgUGLua4jUsuz0bcqb5ZxyAJqgv1X78E0mOZj0=
 github.com/web3-protocol/web3protocol-go v0.2.13/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.14 h1:ckILVqPZJeMo8e8g7em0yG5jQ2pzpydzMDQ41Abf+qo=
+github.com/web3-protocol/web3protocol-go v0.2.14/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -513,6 +513,8 @@ github.com/web3-protocol/web3protocol-go v0.2.13 h1:Xsw0KcgUGLua4jUsuz0bcqb5ZxyA
 github.com/web3-protocol/web3protocol-go v0.2.13/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/web3-protocol/web3protocol-go v0.2.14 h1:ckILVqPZJeMo8e8g7em0yG5jQ2pzpydzMDQ41Abf+qo=
 github.com/web3-protocol/web3protocol-go v0.2.14/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
+github.com/web3-protocol/web3protocol-go v0.2.15 h1:lY3PN5Ue6EPOgb3GZnoQGyz2T91h6lkmmxLKKctDb/0=
+github.com/web3-protocol/web3protocol-go v0.2.15/go.mod h1:IAGxUc/5IoLANkn/L+Xx4+B98V52j/hLCFkPeN5aCw0=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi!

These changes are here to help with web3:// integration in HTML pages with the gateway.
There is already some javascript injected to replace web3:// links, but after working with someone doing a web3:// website, we have found plenty of places where to improve that : 

- Added some extra javascript to handle more cases. The current javascript only work when specifically editing an attribute of a node, but it does not work with insertAdjacentHTML() inserting raw HTML.
- Fix insertion of the javascript patch : the `<body>` tag may have attributes. Right now it only expect `<body>` without attribute.
- Added direct edition of the HTML itself, when the web3:// links are directly in the HTML.
- Editing of the response Location HTTP header, when using 301/302 HTTP redirects.
- web3protocol-go update: ERC-7774 caching: Add support for wildcards in cache clearing events as specified in the ERC 
- web3protocol-go update: ERC-7774 caching: evm-events cache-control header: Fix: Handle multiple values as specified in the ERC.

Thanks for reviewing!