### PR TITLE
Check links sequentially and retry bad links

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check Links
         id: link-check
-        timeout-minutes: 5
+        timeout-minutes: 10
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -41,11 +41,11 @@ jobs:
             const newLinks = await addLinks();
             console.log('New links', newLinks);
             const allLinks = [...links, ...newLinks];
-            const results = await checkAllLinks(allLinks);
-            if (results.failures.length > 0) {
-              core.setOutput('failures', results.failures.map(f => `- ${f.url}: ${f.error}`).join('\n'));
+            const failures = await checkAllLinks(allLinks);
+            if (failures.size > 0) {
+              core.setOutput('failures', Array.from(failures, ([key, val]) => `${key} -> ${val}`).join('\n'));
             } else {
-              core.setOutput('results', results.all.map(a => `- ${a.url}`).join('\n'));
+              core.setOutput('results', allLinks.join('\n'));
             }
           }
 

--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -84,7 +84,7 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	p, rootGatewayHost, er := handleSubdomain(h, path)
 	if er != nil {
 		log.Errorf("%s%s => Error converting subdomain: %s", h, req.URL.String(), er)
-		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusBadRequest, Err: er})
+		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: er})
 		return
 	}
 	// Make it a full web3 URL
@@ -149,7 +149,7 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	// Fetch the web3 URL
 	fetchedWeb3Url, err := web3protocolClient.FetchUrl(web3Url, reqHttpHeaders)
 	if err != nil {
-		respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: fetchedWeb3Url.HttpCode, Err: err})
+		respondWithErrorPage(w, err)
 		return
 	}
 
@@ -573,6 +573,7 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string, rootGatewayHost st
 	// but nowadays everything is mostly UTF-8, so we just assume it is UTF-8
 	htmlContent := string(alteredBuf)
 
+
 	// In the HTML itself, convert web3:// URLs to gateway URLs
 	// Map of HTML tags to their attributes that could contain web3:// URLs
 	elementWithAttributes := map[string]string{
@@ -589,14 +590,14 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string, rootGatewayHost st
 		"input":  "src",
 		"object": "data",
 	}
-
+	
 	// Lookup each tag in the HTML document, process their attributes
 	htmlTagRegex := regexp.MustCompile(`(?i)<\s*([a-z0-9]+)([^>]*)>`)
 	htmlTagMatches := htmlTagRegex.FindAllStringSubmatch(htmlContent, -1)
 	for _, htmlTagMatch := range htmlTagMatches {
 		tagName := strings.ToLower(htmlTagMatch[1])
 		tagAttributes := htmlTagMatch[2]
-
+		
 		// Check if the tag is in the map of tags to process
 		if attributeName, exists := elementWithAttributes[tagName]; exists {
 			// Find the attribute in the tag attributes
@@ -620,6 +621,7 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string, rootGatewayHost st
 		}
 	}
 
+
 	// Add a javascript patch to the HTML page, just after the "<body>" tag
 	// It will patch the fetch() JS function, and the setter method of various attributes of HTML tags
 	bodyTagIndex := strings.Index(strings.ToLower(htmlContent), "<body")
@@ -635,7 +637,8 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string, rootGatewayHost st
 	closingTagIndex += bodyTagIndex + 1
 	// Insert the patch right after the closing '>' of the body tag
 	htmlContent = htmlContent[:closingTagIndex] + string(htmlPatch) + htmlContent[closingTagIndex:]
-
+	
+	
 	// Convert back to byte array
 	alteredBuf = []byte(htmlContent)
 
@@ -654,3 +657,4 @@ func patchHTMLFile(buf []byte, n int, contentEncoding string, rootGatewayHost st
 
 	return n
 }
+

--- a/it/scripts/index.js
+++ b/it/scripts/index.js
@@ -3,19 +3,19 @@ import { addLinks } from './add-links.mjs';
 import { checkAllLinks } from './check-links.mjs';
 
 async function run() {
-    const results = await checkAllLinks(links);
-    if (results.failures.length > 0) {
-        console.log('Failed links: \n', results.failures.map(f => `- ${f.url}: ${f.error}`).join('\n'));
+    let failures = await checkAllLinks(links);
+    if (failures.size > 0) {
+        console.log('Failed links: \n', Array.from(failures, ([key, value]) => `${key} -> ${value}`).join('\n'));
     } else {
-        console.log('All links are OK: totally', results.all.length);
+        console.log('All links are OK: totally', links.length);
     }
 
     const newLinks = await addLinks();
     console.log('New links', newLinks);
 
-    const newResults = await checkAllLinks(newLinks);
-    if (newResults.failures.length > 0) {
-        console.log('Failed links: \n', newResults.failures.map(f => `- ${f.url}: ${f.error}`).join('\n'));
+    failures = await checkAllLinks(newLinks);
+    if (failures.size > 0) {
+        console.log('Failed links: \n', Array.from(failures, ([key, value]) => `${key} -> ${value}`).join('\n'));
     } else {
         console.log('New links are OK');
     }


### PR DESCRIPTION
Check links sequentially to lower the burden of the gateway server and RPCs, and retry bad links in case of temporary service unavailable.

Test results can be found [here](https://github.com/ethstorage/web3url-gateway/actions/runs/14968100815/job/42042585396).