### PR TITLE
More conversions of web3:// URLs into proxy HTTPS URLs

### DIFF
--- a/cmd/server/html.patch
+++ b/cmd/server/html.patch
@@ -144,18 +144,24 @@
             // Find all nodes that have a web3:// URL in their attribute as defined in elementsWithUrlAttr
             elementsWithUrlAttr.forEach(function(elementWithUrlAttr) {
               const nodes = [...addedNode.querySelectorAll(elementWithUrlAttr.tagName + '[' + elementWithUrlAttr.attrName + '^="web3://"]')];
-              if(addedNode.tagName === elementWithUrlAttr.tagName && addedNode[elementWithUrlAttr.attrName].startsWith('web3://')) {
+              // Check if the addedNode itself matches the tag and has the attribute starting with web3://
+              if (
+                addedNode.tagName === elementWithUrlAttr.tagName.toUpperCase() &&
+                typeof addedNode.getAttribute === 'function' &&
+                typeof addedNode.getAttribute(elementWithUrlAttr.attrName) === 'string' &&
+                addedNode.getAttribute(elementWithUrlAttr.attrName).startsWith('web3://')
+              ) {
                 nodes.push(addedNode);
               }
               nodes.forEach(function(node) {
-                const targetUrl = node[elementWithUrlAttr.attrName];
+                const targetUrl = node.getAttribute(elementWithUrlAttr.attrName);
                 const convertedUrl = convertWeb3UrlToGatewayUrl(targetUrl);
                 if(convertedUrl == null) {
                   console.error("Gateway " + node.tagName + " injection wrapper: Unable to convert web3:// URL: " + targetUrl);
                   return;
                 }
                 console.log('Gateway ' + node.tagName + ' injection wrapper: Converted ' + targetUrl + ' to ' + convertedUrl);
-                node[elementWithUrlAttr.attrName] = convertedUrl;
+                node.setAttribute(elementWithUrlAttr.attrName, convertedUrl);
               });
             });
           });

--- a/cmd/server/html.patch
+++ b/cmd/server/html.patch
@@ -108,25 +108,31 @@
       {tagName: 'embed', attrName: 'src'}, // <embed>
       {tagName: 'input', attrName: 'src'}, // <input type="image">
       {tagName: 'object', attrName: 'data'}, // <object>
+      {tagName: 'image', attrName: 'href'}, // <image> of SVG
     ];
     // Override the setter of the attribute to convert web3:// URLs into gateway URLs
     elementsWithUrlAttr.forEach(function(elementWithUrlAttr) {
       const element = document.createElement(elementWithUrlAttr.tagName);
-      const originalAttrSetter = Object.getOwnPropertyDescriptor(element.constructor.prototype, elementWithUrlAttr.attrName).set;
-      Object.defineProperty(element.constructor.prototype, elementWithUrlAttr.attrName, {
+      const proto = element.constructor.prototype;
+      const descriptor = Object.getOwnPropertyDescriptor(proto, elementWithUrlAttr.attrName);
+      if (!descriptor || typeof descriptor.set !== 'function') {
+        // Skip if no setter (e.g., SVG <image> 'href')
+        return;
+      }
+      Object.defineProperty(proto, elementWithUrlAttr.attrName, {
         set: function(attrValue) {
           if(attrValue.startsWith('web3://')) {
             const convertedUrl = convertWeb3UrlToGatewayUrl(attrValue);
             if(convertedUrl == null) {
               console.error("Gateway " + element.name + " " + elementWithUrlAttr.attrName + " setter wrapper: Unable to convert web3:// URL: " + attrValue);
-              originalAttrSetter.call(this, attrValue);
+              descriptor.set.call(this, attrValue);
               return;
             }
             console.log('Gateway ' + element.name + ' ' + elementWithUrlAttr.attrName + ' setter wrapper: Converted ' + attrValue + ' to ' + convertedUrl);
-            originalAttrSetter.call(this, convertedUrl);
+            descriptor.set.call(this, convertedUrl);
           }
           else {
-            originalAttrSetter.call(this, attrValue);
+            descriptor.set.call(this, attrValue);
           }
         }
       });


### PR DESCRIPTION
Hi!

Please consider this patch : this is more support for converting web3:// URLs at more places : 

- In javascript (via `node.innerHTML = 'xx'`) : add support for `<image href="">`, which is a tag used in `<svg>` tags.
- In javascript (via `insertAdjacentHTML('beforeend', xxx)` : Fix support for the root tag being inserted (conversion of `<div><img src="web3://xx"></div>` worked, but not `<img src="web3://xx">` without the wrapping `<div>`)
- In SVG files themselves : handle `<image href="">`
- In CSS files themselves, and in HTML : handle `url('')` (e.g. `background-image: url("web3://xxx");`)

Thanks for the reviewing!