### PR TITLE
Fix timeout in 'check link` action

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check Links
         id: link-check
-        timeout-minutes: 10
+        timeout-minutes: 30
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |


### PR DESCRIPTION
The action 'Check Links' has timed out after 10 minutes because the Sepolia transaction cannot be confirmed in time.
Extend the timeout setting to 30 minutes.