### PR TITLE
Handle the server scenario: Run as HTTP behind HTTPS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,35 @@ KeyFile = "/etc/letsencrypt/live/1.web3gateway.dev/privkey.pem"
 ```
 
 In contrast, `w3link.io` and `w3eth.io` are running with `RunAsHttp` set to `true`, which indicates `autocert` service is not utilized.
+
+## HTTP/HTTPS Proxy Configuration
+
+When running the web3:// gateway behind an HTTPS proxy (such as a reverse proxy or load balancer), you need to configure the `IsBehindHttpsProxy` setting to ensure proper URL generation.
+
+### Configuration Options
+
+- `RunAsHttp`: Controls whether the server itself runs on HTTP or HTTPS
+- `IsBehindHttpsProxy`: Indicates if the HTTP server is behind an HTTPS proxy
+
+### Usage Scenarios
+
+**Scenario 1: Direct HTTPS server**
+```toml
+RunAsHttp = false
+IsBehindHttpsProxy = false
+```
+Use this when the server directly handles HTTPS connections with its own certificates.
+
+**Scenario 2: Direct HTTP server**
+```toml
+RunAsHttp = true
+IsBehindHttpsProxy = false
+```
+Use this for local development or when the server only handles HTTP traffic.
+
+**Scenario 3: HTTP server behind HTTPS proxy**
+```toml
+RunAsHttp = true
+IsBehindHttpsProxy = true
+```
+Use this when the server runs as HTTP internally but is accessed through an HTTPS proxy. This ensures that web3:// URLs are converted to HTTPS gateway URLs instead of HTTP, maintaining proper protocol consistency for end users.

--- a/cmd/server/helper.go
+++ b/cmd/server/helper.go
@@ -20,21 +20,22 @@ import (
 )
 
 type Web3Config struct {
-	ServerPort      string
-	Verbosity       int
-	CertificateFile string
-	KeyFile         string
-	RunAsHttp       bool
-	AutoCertEmail   string
-	SystemCertDir   string
-	DefaultChain    int
-	HomePage        string
-	CORS            string
-	PageCache       PageCacheConfig
-	NSDefaultChains map[string]int
-	Name2Chain      map[string]int
-	ChainConfigs    map[int]ChainConfig
-	RequestLimit    int
+	ServerPort         string
+	Verbosity          int
+	CertificateFile    string
+	KeyFile            string
+	RunAsHttp          bool
+	IsBehindHttpsProxy bool
+	AutoCertEmail      string
+	SystemCertDir      string
+	DefaultChain       int
+	HomePage           string
+	CORS               string
+	PageCache          PageCacheConfig
+	NSDefaultChains    map[string]int
+	Name2Chain         map[string]int
+	ChainConfigs       map[int]ChainConfig
+	RequestLimit       int
 }
 
 type PageCacheConfig struct {
@@ -243,7 +244,7 @@ func ConvertWeb3UrlToGatewayUrl(web3Url string, rootGatewayHost string) (string,
 	}
 
 	protocol := "https"
-	if config.RunAsHttp {
+	if config.RunAsHttp && !config.IsBehindHttpsProxy {
 		protocol = "http"
 	}
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,5 +1,6 @@
 ServerPort = "80"
 RunAsHttp = false
+IsBehindHttpsProxy = false
 AutoCertEmail = ""
 SystemCertDir = ""
 CertificateFile = ""


### PR DESCRIPTION
Hi!

w3link.io is running as http (with runAsHttp=true), and is behind a HTTPS proxy.
This currently break the generation of HTTP URLs with `ConvertWeb3UrlToGatewayUrl()` as they start with `http://`, and so when loading a page in w3link.io, inside the HTML page, we get web3:// URLs converted into http:// URLs, and they are not loaded.

This patch introduce the new config field `IsBehindHttpsProxy` to handle this scenario. Set this flag to true for w3link.io, and the issue will be solved.

Thanks!