### PR TITLE
Extra attribute target for web3:// -> https:// URL replacement

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -599,6 +599,7 @@ func patchTextFile(buf []byte, n int, contentType string, contentEncoding string
 			"a":      "href",
 			"image":  "href",
 			"script": "href",
+			"object": "data",
 		}
 	}
 	


### PR DESCRIPTION
Hi!

Here is a tiny change: 
For `image/svg+xml` content: Add `web3://` -> `https://` URL replacement for the `data` attr of the `<object>` tag.

Thanks!