### PR TITLE
Add test links of objects stored on EthStorage testnet

### DIFF
--- a/it/data/links.mjs
+++ b/it/data/links.mjs
@@ -8,6 +8,9 @@ export const links = [
   // call gas > 50000000:
   "https://nouns-wtf.w3eth.io/render/505",
   "https://moon-birds-xyz.w3eth.io/render/9880",
+  // home page assets stored on EthStorage Sepolia testnet
+  "https://web3url.w3eth.io/assets/logo-BOgUDNUW.svg",
+  "https://web3url.w3eth.io/assets/video-Cf4tQ2mp.webm",
 
   // w3link.io
   "https://0x4200000000000000000000000000000000000800.100011.w3link.io/name?returns=(string)",


### PR DESCRIPTION
- We already have test cases for adding new links to the ES testnet, but not for existing ones.  
- The es-node may stop functioning due to a data integrity breach caused by, e.g., the Ethereum RPC node migration.

Therefore, the links added would be useful to health check the homepage as well as the es-node behind it.
