### PR TITLE
check link test: skip opsep

### DIFF
--- a/it/scripts/add-links.mjs
+++ b/it/scripts/add-links.mjs
@@ -43,7 +43,7 @@ export async function addLinks() {
             configs.push(
                 { rpc: L1_RPC_SEP, type: 2, chainId: 3333, shortName: "es-t" },
                 { rpc: "https://rpc.delta.testnet.l2.quarkchain.io:8545", type: 1, chainId: 110011, shortName: "qkc-l2-t" },
-                { rpc: "https://optimism-sepolia-public.nodies.app", type: 1, chainId: 11155420, shortName: "opsep" },
+                // { rpc: "https://optimism-sepolia-public.nodies.app", type: 1, chainId: 11155420, shortName: "opsep" },
                 { rpc: "https://sepolia.base.org", type: 1, chainId: 84532, shortName: "basesep" },
             );
         }


### PR DESCRIPTION

Skip OP Sepolia test due to
>OP Stack Sepolia testnet chains have a bug affecting calls to eth_estimateGas when the gas parameter is omitted after Karst. If you use eth_estimateGas, providing an explicit gas parameter is required. Only post-Karst Sepolia OP Stack chains are impacted. This will be fixed on OP Sepolia within the coming days and will be fixed prior to Karst activation on OP Mainnet.


ref: https://docs.optimism.io/notices/upgrade-19#for-app-developers