### PR TITLE
fix: prevent response panic when patchTextFile result exceeds buffer capacity

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -302,15 +302,16 @@ func handle(w http.ResponseWriter, req *http.Request) {
 		// - Inject a javascript patch to the HTML page, which :
 		//   - Patch the fetch() JS function so that it works with web3:// URLs
 		//   - Patch the setter method of various attributes of HTML tags (e.g. <a>, <img>, etc.)
+		chunk := buf[:n]
 		if strings.HasPrefix(w.Header().Get("Content-Type"), "text/html") || strings.HasPrefix(w.Header().Get("Content-Type"), "text/css") || strings.HasPrefix(w.Header().Get("Content-Type"), "image/svg+xml") {
-			n = patchTextFile(buf, n, w.Header().Get("Content-Type"), w.Header().Get("Content-Encoding"), rootGatewayHost)
+			chunk = patchTextFile(chunk, w.Header().Get("Content-Type"), w.Header().Get("Content-Encoding"), rootGatewayHost)
 		}
 
 		// Update the total output data length
-		outputDataLength += n
+		outputDataLength += len(chunk)
 
 		// Feed the data to the HTTP client
-		_, err = w.Write(buf[:n])
+		_, err = w.Write(chunk)
 		if err != nil {
 			respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
 			return
@@ -322,7 +323,7 @@ func handle(w http.ResponseWriter, req *http.Request) {
 			willCacheResponseAsType = ""
 		}
 		if willCacheResponseAsType != "" {
-			_, err = cacheResponseWriter.Write(buf[:n])
+			_, err = cacheResponseWriter.Write(chunk)
 			if err != nil {
 				respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
 				return
@@ -555,29 +556,30 @@ func handleSubdomain(host string, path string) (p string, rootGatewayHost string
 //go:embed html.patch
 var htmlPatch []byte
 
-func patchTextFile(buf []byte, n int, contentType string, contentEncoding string, rootGatewayHost string) int {
-	// Create a new buffer of length n, and copy the data into it
-	alteredBuf := make([]byte, n)
-	copy(alteredBuf, buf[:n])
+// patchTextFile returns the patched content. The result can be longer than the
+// input (the injected html.patch alone adds ~8 KB), so it must not be written
+// back into the caller's buffer.
+func patchTextFile(data []byte, contentType string, contentEncoding string, rootGatewayHost string) []byte {
+	content := data
 
 	// If contentEncoding is "gzip", then first decompress the data
 	if contentEncoding == "gzip" {
-		gzipReader, err := gzip.NewReader(bytes.NewReader(alteredBuf))
+		gzipReader, err := gzip.NewReader(bytes.NewReader(data))
 		if err != nil {
 			log.Infof("patchTextFile: Cannot initiate gzip decompression: %v\n", err)
-			return n
+			return data
 		}
-		alteredBuf, err = io.ReadAll(gzipReader)
+		content, err = io.ReadAll(gzipReader)
 		if err != nil {
 			log.Infof("patchTextFile: Cannot decompress gzip data (likely spread over several chunks): %v\n", err)
-			return n
+			return data
 		}
 	}
 
 	// Convert the buffer to a string
 	// We should theorically look for the charset, located in a <meta charset="xxx" /> tag,
 	// but nowadays everything is mostly UTF-8, so we just assume it is UTF-8
-	textContent := string(alteredBuf)
+	textContent := string(content)
 
 	// In the text itself, convert web3:// URLs to gateway URLs
 	// Map of XML tags to their attributes that could contain web3:// URLs
@@ -663,12 +665,12 @@ func patchTextFile(buf []byte, n int, contentType string, contentEncoding string
 	if strings.HasPrefix(contentType, "text/html") {
 		bodyTagIndex := strings.Index(strings.ToLower(textContent), "<body")
 		if bodyTagIndex == -1 {
-			return n
+			return data
 		}
 		// Find the closing '>' of the body tag
 		closingTagIndex := strings.Index(textContent[bodyTagIndex:], ">")
 		if closingTagIndex == -1 {
-			return n
+			return data
 		}
 		// Calculate the actual position of the closing '>' in the full string
 		closingTagIndex += bodyTagIndex + 1
@@ -677,20 +679,16 @@ func patchTextFile(buf []byte, n int, contentType string, contentEncoding string
 	}
 
 	// Convert back to byte array
-	alteredBuf = []byte(textContent)
+	patched := []byte(textContent)
 
 	// If contentEncoding is "gzip", then recompress the data
 	if contentEncoding == "gzip" {
 		var compressedBuf bytes.Buffer
 		gzipWriter := gzip.NewWriter(&compressedBuf)
-		gzipWriter.Write(alteredBuf)
+		gzipWriter.Write(patched)
 		gzipWriter.Close()
-		alteredBuf = compressedBuf.Bytes()
+		patched = compressedBuf.Bytes()
 	}
 
-	// Finally: copy the altered data back into the original buffer and update n
-	copy(buf, alteredBuf)
-	n = len(alteredBuf)
-
-	return n
+	return patched
 }

--- a/cmd/server/protocol_patch_test.go
+++ b/cmd/server/protocol_patch_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// patchTestDoc builds an HTML document of approximately size bytes containing
+// numLinks <a href="web3://..."> tags.
+func patchTestDoc(size int, numLinks int) []byte {
+	var b bytes.Buffer
+	b.WriteString("<html><head><title>t</title></head><body>\n")
+	for i := 0; i < numLinks; i++ {
+		fmt.Fprintf(&b, `<a href="web3://0x1e9796FA683cBDaA29B5fD5267FebED6D4b9124b:1/assets/%d">l%d</a>`+"\n", i, i)
+	}
+	filler := strings.Repeat("x", 1024)
+	for b.Len() < size-64 {
+		b.WriteString("<p>")
+		b.WriteString(filler)
+		b.WriteString("</p>\n")
+	}
+	b.WriteString("</body></html>")
+	return b.Bytes()
+}
+
+// TestPatchTextFileGrowsBeyondInputBuffer is the regression test for the
+// out-of-bounds panic: patchTextFile used to write its result back into the
+// caller's buffer and return the *expanded* length, so `w.Write(buf[:n])`
+// panicked whenever the patch pushed the content past the buffer capacity.
+// The threshold was cap(buf) - len(htmlPatch), reachable by any page that
+// nearly fills the read buffer.
+func TestPatchTextFileGrowsBeyondInputBuffer(t *testing.T) {
+	for _, bufSize := range []int{64 * 1024, 256 * 1024} {
+		t.Run(fmt.Sprintf("%dKiB", bufSize/1024), func(t *testing.T) {
+			// A page that leaves less room than the patch needs.
+			doc := patchTestDoc(bufSize-1024, 0)
+			buf := make([]byte, bufSize)
+			n := copy(buf, doc)
+
+			got := patchTextFile(buf[:n], "text/html", "", "w3link.io")
+
+			if len(got) <= bufSize {
+				t.Fatalf("test is not exercising the overflow: len=%d, buffer=%d", len(got), bufSize)
+			}
+			if want := n + len(htmlPatch); len(got) != want {
+				t.Errorf("len(got)=%d, want %d", len(got), want)
+			}
+			// The caller writes the returned slice directly; this used to panic.
+			var sink bytes.Buffer
+			if _, err := sink.Write(got); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if !bytes.Contains(got, []byte("</body></html>")) {
+				t.Error("document was truncated: closing tags are gone")
+			}
+		})
+	}
+}
+
+// TestPatchTextFileDoesNotMutateInput pins the new contract: the input slice is
+// read-only, so the caller's read buffer stays intact and reusable.
+func TestPatchTextFileDoesNotMutateInput(t *testing.T) {
+	doc := patchTestDoc(8*1024, 5)
+	input := make([]byte, len(doc))
+	copy(input, doc)
+
+	patchTextFile(input, "text/html", "", "w3link.io")
+
+	if !bytes.Equal(input, doc) {
+		t.Error("patchTextFile modified its input slice")
+	}
+}
+
+func TestPatchTextFileRewritesWeb3Urls(t *testing.T) {
+	doc := patchTestDoc(4*1024, 3)
+	got := patchTextFile(doc, "text/html", "", "w3link.io")
+
+	if bytes.Contains(got, []byte("web3://0x1e9796")) {
+		t.Error("web3:// link was not rewritten")
+	}
+	if !bytes.Contains(got, []byte(".w3link.io/assets/0")) {
+		t.Error("rewritten link does not point at the gateway host")
+	}
+	if !bytes.Contains(got, htmlPatch) {
+		t.Error("html.patch was not injected")
+	}
+}
+
+func TestPatchTextFileGzipRoundTrip(t *testing.T) {
+	doc := patchTestDoc(16*1024, 3)
+
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	zw.Write(doc)
+	zw.Close()
+
+	got := patchTextFile(compressed.Bytes(), "text/html", "gzip", "w3link.io")
+
+	zr, err := gzip.NewReader(bytes.NewReader(got))
+	if err != nil {
+		t.Fatalf("result is not valid gzip: %v", err)
+	}
+	decompressed, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if !bytes.Contains(decompressed, htmlPatch) {
+		t.Error("html.patch was not injected into the gzip payload")
+	}
+	if bytes.Contains(decompressed, []byte("web3://0x1e9796")) {
+		t.Error("web3:// link was not rewritten in the gzip payload")
+	}
+}
+
+// Content that cannot be patched is returned unchanged, in its original
+// encoding -- not the decompressed intermediate.
+func TestPatchTextFilePassesThroughUnpatchable(t *testing.T) {
+	noBody := []byte("<html><head><title>t</title></head></html>")
+	if got := patchTextFile(noBody, "text/html", "", "w3link.io"); !bytes.Equal(got, noBody) {
+		t.Errorf("no <body> tag: got %q, want it unchanged", got)
+	}
+
+	notGzip := []byte("<html><body>plain</body></html>")
+	if got := patchTextFile(notGzip, "text/html", "gzip", "w3link.io"); !bytes.Equal(got, notGzip) {
+		t.Errorf("undecompressable gzip: got %q, want the original bytes back", got)
+	}
+}


### PR DESCRIPTION
## Problem

Patching an HTML response can make it larger than the buffer used to read it. The injected JavaScript alone adds about 8 KB.

Previously, `patchTextFile` copied the expanded content back into that fixed-size buffer but returned the full expanded length. If the content exceeded the buffer capacity, the copy truncated it and `handle()` panicked when slicing `buf[:n]`.

This can happen with responses that nearly fill the current 8 MiB buffer. Reducing the buffer size would make it more common.

## Fix

`patchTextFile` now returns the patched bytes directly and leaves its input unchanged. The handler uses the returned slice for HTTP output, cache writes, and response-size accounting.

This preserves the complete patched response even when it grows beyond the read buffer. Existing URL rewriting, JavaScript injection, and gzip handling remain unchanged.

## Validation

Regression tests in `cmd/server/protocol_patch_test.go` cover:

- **Buffer growth:** HTML content expands beyond 64 KiB and 256 KiB buffers without truncation.
- **Input preservation:** patching does not modify the original bytes.
- **Output correctness:** web3 URLs are rewritten and the JavaScript patch is injected, including after a gzip round trip.
- **Pass-through:** HTML without a body tag and invalid gzip data are returned unchanged.

All patch regression tests pass with the sample configuration:

```sh
go test ./... -run '^TestPatchTextFile' -count=1
```

A manual end-to-end check through `handle()` and `requestLimiter` also returned the complete 74,378-byte response for a roughly 64 KB page containing 50 web3 links.

