### PR TITLE
fix: stop reserving an 8 MiB read buffer per request

### DIFF
--- a/cmd/server/protocol.go
+++ b/cmd/server/protocol.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -57,6 +58,26 @@ type PageCacheEntry struct {
 
 	// The time at which the cache entry was created
 	CreationTime time.Time
+}
+
+const (
+	// Buffer used to move a response body from web3protocol-go to the client. It was
+	// 8 MiB, allocated per request before the body size was known, and
+	// web3protocol-go's SharedOutputReader mirrors whatever size we pass it -- so an
+	// empty response cost 16 MiB of zeroed pages. Going bigger buys nothing: the body
+	// is already in memory upstream, so it only saves loop iterations.
+	responseBufferSize = 64 * 1024
+	// Upper bound on a body we accumulate to patch as one document -- the ceiling the
+	// old 8 MiB read buffer already imposed, now reached by growing with the body
+	// instead of being reserved up front.
+	maxPatchableBodySize = 8 * 1024 * 1024
+)
+
+var responseBufferPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, responseBufferSize)
+		return &buf
+	},
 }
 
 func handle(w http.ResponseWriter, req *http.Request) {
@@ -282,39 +303,16 @@ func handle(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Send the output
-	// We receive it chunk by chunk from web3protocol-go. Usually there is only a single chunk.
+	// We receive it chunk by chunk from web3protocol-go.
 	outputDataLength := 0
-	buf := make([]byte, 8*1024*1024)
-	for {
-		// Fetch data from web3protocol-go
-		n, err := fetchedWeb3Url.Output.Read(buf)
-		if err != nil && err != io.EOF {
-			respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
-			return
-		}
-		if n == 0 {
-			break
-		}
-
-		// If the content type is some specific text types,
-		// we do some processing on the data
-		// - Rewrite the web3:// URLs of the HTML tags (e.g. <a>, <img>, etc.)
-		// - Inject a javascript patch to the HTML page, which :
-		//   - Patch the fetch() JS function so that it works with web3:// URLs
-		//   - Patch the setter method of various attributes of HTML tags (e.g. <a>, <img>, etc.)
-		chunk := buf[:n]
-		if strings.HasPrefix(w.Header().Get("Content-Type"), "text/html") || strings.HasPrefix(w.Header().Get("Content-Type"), "text/css") || strings.HasPrefix(w.Header().Get("Content-Type"), "image/svg+xml") {
-			chunk = patchTextFile(chunk, w.Header().Get("Content-Type"), w.Header().Get("Content-Encoding"), rootGatewayHost)
-		}
-
-		// Update the total output data length
+	// sendChunk feeds one piece of the body to the client and, while the response is
+	// still eligible, to the cache. It returns false once the error page has been sent.
+	sendChunk := func(chunk []byte) bool {
 		outputDataLength += len(chunk)
 
-		// Feed the data to the HTTP client
-		_, err = w.Write(chunk)
-		if err != nil {
+		if _, err := w.Write(chunk); err != nil {
 			respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
-			return
+			return false
 		}
 
 		// Feed the data to the cache, if enabled
@@ -323,10 +321,9 @@ func handle(w http.ResponseWriter, req *http.Request) {
 			willCacheResponseAsType = ""
 		}
 		if willCacheResponseAsType != "" {
-			_, err = cacheResponseWriter.Write(chunk)
-			if err != nil {
+			if _, err := cacheResponseWriter.Write(chunk); err != nil {
 				respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
-				return
+				return false
 			}
 		}
 
@@ -334,6 +331,57 @@ func handle(w http.ResponseWriter, req *http.Request) {
 		// (This is still an HTTP 1.1 server, so it's using Transfer-encoding: chunked)
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
+		}
+		return true
+	}
+
+	// For some specific text types we do some processing on the data
+	// - Rewrite the web3:// URLs of the HTML tags (e.g. <a>, <img>, etc.)
+	// - Inject a javascript patch to the HTML page, which :
+	//   - Patch the fetch() JS function so that it works with web3:// URLs
+	//   - Patch the setter method of various attributes of HTML tags (e.g. <a>, <img>, etc.)
+	// Both need the whole document at once -- a tag straddling two reads would be
+	// missed, and the patch would land in whichever chunk holds the <body> tag -- so
+	// those bodies are accumulated first.
+	contentType := w.Header().Get("Content-Type")
+	patchBody := strings.HasPrefix(contentType, "text/html") || strings.HasPrefix(contentType, "text/css") || strings.HasPrefix(contentType, "image/svg+xml")
+	var patchableBody []byte
+
+	buf := responseBufferPool.Get().(*[]byte)
+	defer responseBufferPool.Put(buf)
+	for {
+		// Fetch data from web3protocol-go
+		n, err := fetchedWeb3Url.Output.Read(*buf)
+		if err != nil && err != io.EOF {
+			respondWithErrorPage(w, &web3protocol.Web3ProtocolError{HttpCode: http.StatusServiceUnavailable, Err: err})
+			return
+		}
+		if n == 0 {
+			break
+		}
+		chunk := (*buf)[:n]
+
+		if patchBody {
+			if len(patchableBody)+n <= maxPatchableBodySize {
+				patchableBody = append(patchableBody, chunk...)
+				continue
+			}
+			// Bigger than we are willing to hold: patch what we have, as the old
+			// fixed-size buffer did with its first chunk, then stream the rest raw.
+			log.Warnf("Body of %s exceeds %d bytes, serving the remainder unpatched\n", web3Url, maxPatchableBodySize)
+			if !sendChunk(patchTextFile(patchableBody, contentType, w.Header().Get("Content-Encoding"), rootGatewayHost)) {
+				return
+			}
+			patchBody, patchableBody = false, nil
+		}
+
+		if !sendChunk(chunk) {
+			return
+		}
+	}
+	if len(patchableBody) > 0 {
+		if !sendChunk(patchTextFile(patchableBody, contentType, w.Header().Get("Content-Encoding"), rootGatewayHost)) {
+			return
 		}
 	}
 

--- a/cmd/server/protocol_body_test.go
+++ b/cmd/server/protocol_body_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Response bodies are streamed through a small pooled buffer, so a body now
+// routinely arrives in several reads. These tests drive the real handler
+// against a mocked JSON-RPC node; nothing leaves the machine.
+
+const testChainId = 31337
+
+var resolveModeSelector = "0x" + hex.EncodeToString(crypto.Keccak256([]byte("resolveMode()"))[:4])
+
+// abiEncodeBytes ABI-encodes payload as a single `bytes` return value.
+func abiEncodeBytes(payload []byte) string {
+	var b bytes.Buffer
+	word := func(v int) {
+		var w [32]byte
+		for i, n := 31, v; i >= 0 && n > 0; i, n = i-1, n>>8 {
+			w[i] = byte(n & 0xff)
+		}
+		b.Write(w[:])
+	}
+	word(32) // offset of the bytes value
+	word(len(payload))
+	b.Write(payload)
+	if pad := len(payload) % 32; pad != 0 {
+		b.Write(make([]byte, 32-pad))
+	}
+	return "0x" + hex.EncodeToString(b.Bytes())
+}
+
+// gatewayServingBody returns a gateway whose test chain answers every contract
+// call with payload. An empty resolveMode() return selects "auto" mode.
+func gatewayServingBody(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	encoded := abiEncodeBytes(payload)
+
+	rpc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Id json.RawMessage `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		result := encoded
+		if bytes.Contains(body, []byte(resolveModeSelector+`"`)) {
+			result = "0x"
+		}
+		if len(req.Id) == 0 {
+			req.Id = json.RawMessage("1")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, req.Id, result)
+	}))
+	t.Cleanup(rpc.Close)
+
+	config.ChainConfigs[testChainId] = ChainConfig{ChainID: testChainId, RPC: rpc.URL, SystemRPC: rpc.URL}
+	initWeb3protocolClient()
+	t.Cleanup(func() {
+		delete(config.ChainConfigs, testChainId)
+		initWeb3protocolClient()
+	})
+
+	gw := httptest.NewServer(http.HandlerFunc(handle))
+	t.Cleanup(gw.Close)
+	return gw
+}
+
+// fetchBody asks the gateway for path and returns the response body.
+func fetchBody(t *testing.T, gw *httptest.Server, path string) []byte {
+	t.Helper()
+	req, err := http.NewRequest("GET", gw.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = fmt.Sprintf("0x1e9796fa683cbdaa29b5fd5267febed6d4b9124b.%d.w3link.io", testChainId)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+	return body
+}
+
+// A body several buffers long must arrive byte for byte. The pattern makes a
+// lost, reordered or duplicated read show up as a mismatch, not just a length
+// change -- the read buffer is pooled and reused, so stale content would show.
+func TestResponseBodyStreamsIntact(t *testing.T) {
+	payload := make([]byte, 5*responseBufferSize+1234)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	got := fetchBody(t, gatewayServingBody(t, payload), "/data/1?mime.type=bin")
+
+	if !bytes.Equal(got, payload) {
+		t.Errorf("body mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// Patchable content is accumulated before being patched, so a link straddling a
+// read boundary is still rewritten and the javascript patch is injected once.
+// Patching each read on its own would miss the link and inject nothing.
+func TestPatchableBodySpanningReadsIsPatchedAsOneDocument(t *testing.T) {
+	head := "<html><body>"
+	link := `<a href="web3://0x1e9796FA683cBDaA29B5fD5267FebED6D4b9124b:1/assets/x">l</a>`
+	// Start the link 20 bytes before the first read boundary, so it is cut in two.
+	doc := head + strings.Repeat("y", responseBufferSize-len(head)-20) + link +
+		strings.Repeat("z", 2*responseBufferSize) + "</body></html>"
+
+	got := fetchBody(t, gatewayServingBody(t, []byte(doc)), "/page/1?mime.type=html")
+
+	if bytes.Contains(got, []byte("web3://0x1e9796")) {
+		t.Error("link straddling a read boundary was not rewritten")
+	}
+	if !bytes.Contains(got, []byte(".w3link.io/assets/x")) {
+		t.Error("rewritten link does not point at the gateway host")
+	}
+	if n := bytes.Count(got, htmlPatch); n != 1 {
+		t.Errorf("html.patch injected %d times, want exactly 1", n)
+	}
+	if !bytes.HasSuffix(got, []byte("</body></html>")) {
+		t.Error("document was truncated")
+	}
+}
+
+// Past the accumulation limit the body is served unpatched rather than held in
+// memory, and it must still arrive complete.
+func TestOversizedPatchableBodyIsServedComplete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates twice the patchable-body limit")
+	}
+	doc := "<html><body>" + strings.Repeat("y", maxPatchableBodySize) + "</body></html>"
+
+	got := fetchBody(t, gatewayServingBody(t, []byte(doc)), "/page/1?mime.type=html")
+
+	// The patched prefix carries the injected patch; the remainder is untouched.
+	if want := len(doc) + len(htmlPatch); len(got) != want {
+		t.Errorf("got %d bytes, want %d", len(got), want)
+	}
+	if !bytes.HasSuffix(got, []byte("</body></html>")) {
+		t.Error("document was truncated")
+	}
+}
+
+// The incident behind this change was a burst of requests to contracts
+// returning nothing: the read buffer was allocated before the body size was
+// known, so an empty response still cost 8 MiB in the gateway plus 8 MiB in
+// web3protocol-go's SharedOutputReader, which mirrors the size we pass it.
+func TestEmptyResponseDoesNotAllocatePerRequestBuffers(t *testing.T) {
+	gw := gatewayServingBody(t, nil)
+	fetchBody(t, gw, "/warmup?mime.type=bin") // fill the caches and the buffer pool
+
+	const requests = 5
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for i := 0; i < requests; i++ {
+		if body := fetchBody(t, gw, fmt.Sprintf("/empty/%d?mime.type=bin", i)); len(body) != 0 {
+			t.Fatalf("got %d bytes, want an empty body", len(body))
+		}
+	}
+	runtime.ReadMemStats(&after)
+
+	// Generous: the whole request path, mock RPC included, is well under this.
+	perRequest := (after.TotalAlloc - before.TotalAlloc) / requests
+	if perRequest > 1024*1024 {
+		t.Errorf("%d bytes allocated per empty response, want well under 1 MiB", perRequest)
+	}
+}


### PR DESCRIPTION
Closes #108

## What

- Cuts per-request memory from a flat ~16 MiB to what the response actually needs. The gateway used to reserve an 8 MiB read buffer before knowing the body size, and web3protocol-go allocates a matching one, so a burst of requests to contracts returning *nothing* was enough to OOM the process (#108).
- Response bodies now stream through a pooled 64 KiB buffer. Only patchable types (text/html, text/css, image/svg+xml) hold the body in memory, growing with it up to 8 MiB — the ceiling the old fixed buffer already implied. Past that the body is served unpatched instead of held, with a warning.
- Fixes URL rewriting and JS-patch injection for any body that arrives in more than one read: links straddling a read boundary were silently missed, the patch landed in whichever chunk happened to hold `<body>`, and gzip content spread over chunks could not be decompressed at all. Serving behaviour for bodies within one old 8 MiB read is unchanged.

## Test

- New tests drive the real handler over HTTP against a mocked JSON-RPC node (no network, no fixtures): a multi-buffer binary body is compared byte for byte, so a lost, reordered or stale pooled read shows up as a mismatch rather than a length change.
- A link is placed deliberately across the first read boundary to assert it is still rewritten and the JS patch injected exactly once; an oversized document asserts the body still arrives complete.
- The regression itself is pinned by measuring allocation across repeated empty responses and asserting it stays under 1 MiB per request — this failed at ~16 MiB before the change.
- `go build ./... && go vet ./cmd/server && go test ./cmd/server`: new tests pass; the 23 pre-existing failures are unchanged and all come from live-network chain calls (identical set before and after the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
